### PR TITLE
Use generic ID type for primary keys

### DIFF
--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -12,6 +12,7 @@ module HQ
         super
         ::HQ::GraphQL.types << base
         base.include Scalars
+        base.include ::GraphQL::Types
       end
 
       module ClassMethods
@@ -230,9 +231,8 @@ module HQ
             def_root field_name, is_array: false, null: true do
               klass = scoped_self.model_klass
               primary_key = klass.primary_key
-              pk_column = klass.columns.detect { |c| c.name == primary_key.to_s }
 
-              argument primary_key, ::HQ::GraphQL::Types.type_from_column(pk_column), required: true
+              argument primary_key, ::GraphQL::Types::ID, required: true
 
               define_method(:resolve) do |**attrs|
                 scoped_self.find_record(attrs, context)

--- a/lib/hq/graphql/resource/mutation.rb
+++ b/lib/hq/graphql/resource/mutation.rb
@@ -20,9 +20,7 @@ module HQ
               lazy_load do
                 klass = model_name.constantize
                 primary_key = klass.primary_key
-                pk_column = klass.columns.detect { |c| c.name == primary_key.to_s }
-
-                argument primary_key, ::HQ::GraphQL::Types.type_from_column(pk_column), required: true
+                argument primary_key, ::GraphQL::Types::ID, required: true
               end
             end
 

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -243,7 +243,7 @@ describe ::HQ::GraphQL::Resource do
   context "execution" do
     let(:find_advisor) {
       <<-GRAPHQL
-        query findAdvisor($id: UUID!){
+        query findAdvisor($id: ID!){
           advisor(id: $id) {
             name
             organizationId
@@ -272,7 +272,7 @@ describe ::HQ::GraphQL::Resource do
 
     let(:update_mutation) {
       <<-GRAPHQL
-        mutation updateAdvisor($id: UUID!, $attributes: AdvisorInput!){
+        mutation updateAdvisor($id: ID!, $attributes: AdvisorInput!){
           updateAdvisor(id: $id, attributes: $attributes) {
             errors
             resource {
@@ -288,7 +288,7 @@ describe ::HQ::GraphQL::Resource do
 
     let(:destroy_mutation) {
       <<-GRAPHQL
-        mutation destroyAdvisor($id: UUID!){
+        mutation destroyAdvisor($id: ID!){
           destroyAdvisor(id: $id) {
             errors
             resource {


### PR DESCRIPTION
This provides a bit of consistency when using mutations. We don't need to worry if something is a number or a string