### PR TITLE
Configurable resource class resolution

### DIFF
--- a/lib/hq/graphql.rb
+++ b/lib/hq/graphql.rb
@@ -28,6 +28,10 @@ module HQ
       config.default_scope.call(scope, context)
     end
 
+    def self.extract_class(klass)
+      config.extract_class.call(klass)
+    end
+
     def self.resource_lookup(klass)
       config.resource_lookup.call(klass)
     end

--- a/lib/hq/graphql/config.rb
+++ b/lib/hq/graphql/config.rb
@@ -2,10 +2,18 @@
 
 module HQ
   module GraphQL
-    class Config < Struct.new(:authorize, :authorize_field, :default_scope, :resource_lookup, keyword_init: true)
+    class Config < Struct.new(
+      :authorize,
+      :authorize_field,
+      :default_scope,
+      :extract_class,
+      :resource_lookup,
+      keyword_init: true
+    )
       def initialize(
         default_scope: ->(scope, _context) { scope },
-        resource_lookup: ->(klass) { "::Resources::#{klass}".safe_constantize },
+        extract_class: ->(klass) { klass.to_s.gsub(/^Resources|Resource$/, "") },
+        resource_lookup: ->(klass) { "::Resources::#{klass}Resource".safe_constantize || "::Resources::#{klass}".safe_constantize },
         **options
       )
         super

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -37,7 +37,7 @@ module HQ
         end
 
         def model_name
-          @model_name || name.demodulize
+          @model_name || ::HQ::GraphQL.extract_class(self)
         end
 
         def model_klass

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.0.9"
+    VERSION = "2.0.10"
   end
 end

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -258,6 +258,29 @@ describe ::HQ::GraphQL::Resource do
     end
   end
 
+  context "model klass resolution" do
+    def build_resource(stubbed_class)
+      Class.new { include ::HQ::GraphQL::Resource }.tap do |c|
+        stub_const(stubbed_class, c)
+      end
+    end
+
+    it "strips /^Resources/ and /Resource$/" do
+      c = build_resource("Resources::OrganizationResource")
+      expect(c.model_klass).to eq Organization
+    end
+
+    it "strips /^Resources/" do
+      c = build_resource("Resources::Organization")
+      expect(c.model_klass).to eq Organization
+    end
+
+    it "strips /Resource$/" do
+      c = build_resource("OrganizationResource")
+      expect(c.model_klass).to eq Organization
+    end
+  end
+
   context "execution" do
     let(:find_advisor) {
       <<-GRAPHQL


### PR DESCRIPTION
Description
-----------
Configurable resource class resolution.

It defaults to:
```ruby
"Resources::OrganizationResource" => Organization
"Resources::Organization" => Organization
"OrganizationResource" => Organization
```

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
- [ ] If this PR has a jira ticket, I used a [JIRA smart commit](https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html) to link the ticket to this PR.
