### PR TITLE
GraphQL Objects support custom associations

### DIFF
--- a/lib/hq/graphql.rb
+++ b/lib/hq/graphql.rb
@@ -64,7 +64,6 @@ module HQ
   end
 end
 
-require "hq/graphql/active_record_extensions"
 require "hq/graphql/association_loader"
 require "hq/graphql/scalars"
 require "hq/graphql/comparator"

--- a/lib/hq/graphql/enum.rb
+++ b/lib/hq/graphql/enum.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hq/graphql/types"
+
 module HQ::GraphQL
   class Enum < ::GraphQL::Schema::Enum
     ## Auto generate enums from the database using ActiveRecord
@@ -73,6 +75,3 @@ module HQ::GraphQL
     end
   end
 end
-
-require "hq/graphql/enum/sort_by"
-require "hq/graphql/enum/sort_order"

--- a/lib/hq/graphql/enum/sort_by.rb
+++ b/lib/hq/graphql/enum/sort_by.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hq/graphql/enum"
+
 module HQ
   class GraphQL::Enum::SortBy < ::HQ::GraphQL::Enum
     value "CreatedAt", value: :created_at

--- a/lib/hq/graphql/enum/sort_order.rb
+++ b/lib/hq/graphql/enum/sort_order.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "hq/graphql/enum"
+
 module HQ
   class GraphQL::Enum::SortOrder < ::HQ::GraphQL::Enum
     value "ASC", value: :asc

--- a/lib/hq/graphql/field_extension/association_loader_extension.rb
+++ b/lib/hq/graphql/field_extension/association_loader_extension.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "hq/graphql/association_loader"
+
+module HQ
+  module GraphQL
+    module FieldExtension
+      class AssociationLoaderExtension < ::GraphQL::Schema::FieldExtension
+        def resolve(object:, **_kwargs)
+          AssociationLoader.for(options[:klass], field.original_name).load(object.object)
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/graphql/field_extension/paginated_arguments.rb
+++ b/lib/hq/graphql/field_extension/paginated_arguments.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "hq/graphql/enum/sort_by"
+require "hq/graphql/enum/sort_order"
+
+module HQ
+  module GraphQL
+    module FieldExtension
+      class PaginatedArguments < ::GraphQL::Schema::FieldExtension
+        def apply
+          field.argument :offset, Integer, required: false
+          field.argument :limit, Integer, required: false
+          field.argument :sort_order, Enum::SortOrder, required: false
+
+          resource = ::HQ::GraphQL.lookup_resource(options[:klass])
+          enum = resource ? resource.sort_fields_enum : ::HQ::GraphQL::Enum::SortBy
+          field.argument :sort_by, enum, required: false
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/graphql/field_extension/paginated_loader.rb
+++ b/lib/hq/graphql/field_extension/paginated_loader.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "hq/graphql/paginated_association_loader"
+
+module HQ
+  module GraphQL
+    module FieldExtension
+      class PaginatedLoader < ::GraphQL::Schema::FieldExtension
+        def resolve(object:, arguments:, **_options)
+          limit       = arguments[:limit]
+          offset      = arguments[:offset]
+          sort_by     = arguments[:sort_by]
+          sort_order  = arguments[:sort_order]
+          scope       = field.scope.call(**arguments.except(:limit, :offset, :sort_by, :sort_order)) if field.scope
+          loader      = PaginatedAssociationLoader.for(
+            klass,
+            association,
+            internal_association: internal_association,
+            scope:                scope,
+            limit:                limit,
+            offset:               offset,
+            sort_by:              sort_by,
+            sort_order:           sort_order
+          )
+
+          loader.load(object.object)
+        end
+
+        private
+
+        def association
+          options[:association]
+        end
+
+        def internal_association
+          options[:internal_association]
+        end
+
+        def klass
+          options[:klass]
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/graphql/input_object.rb
+++ b/lib/hq/graphql/input_object.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "hq/graphql/active_record_extensions"
+require "hq/graphql/inputs"
+require "hq/graphql/types"
+
 module HQ
   module GraphQL
     class InputObject < ::GraphQL::Schema::InputObject

--- a/lib/hq/graphql/object.rb
+++ b/lib/hq/graphql/object.rb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
+require "hq/graphql/active_record_extensions"
+require "hq/graphql/field"
+require "hq/graphql/field_extension/association_loader_extension"
+require "hq/graphql/field_extension/paginated_arguments"
+require "hq/graphql/field_extension/paginated_loader"
+require "hq/graphql/object_association"
+require "hq/graphql/types"
+
 module HQ
   module GraphQL
     class Object < ::GraphQL::Schema::Object
       include Scalars
-      include ::HQ::GraphQL::ActiveRecordExtensions
+      include ActiveRecordExtensions
+      extend ObjectAssociation
 
-      field_class ::HQ::GraphQL::Field
+      field_class Field
 
       def self.authorize_action(action)
         self.authorized_action = action
@@ -28,7 +37,14 @@ module HQ
           end
 
           model_associations.each do |association|
+            next if resource_reflections[association.name.to_s]
             field_from_association(association, auto_nil: auto_nil)
+          end
+
+          resource_reflections.values.each do |resource_reflection|
+            reflection = resource_reflection.reflection(model_klass)
+            next unless reflection
+            field_from_association(reflection, auto_nil: auto_nil, internal_association: true, &resource_reflection.block)
           end
         end
       end
@@ -46,32 +62,36 @@ module HQ
           @authorized_action ||= :read
         end
 
-        def field_from_association(association, auto_nil:)
+        def field_from_association(association, auto_nil:, internal_association: false, &block)
           # The PaginationAssociationLoader doesn't support through associations yet
           return if association.through_reflection? && ::HQ::GraphQL.use_experimental_associations?
 
           association_klass = association.klass
-          type = ::HQ::GraphQL::Types[association_klass]
-          name = association.name
+          name              = association.name
+          klass             = model_klass
+          type              = Types[association_klass]
           case association.macro
           when :has_many
             field name, [type], null: false, klass: model_name do
-              if ::HQ::GraphQL.use_experimental_associations? && (resource = ::HQ::GraphQL.lookup_resource(association_klass))
-                argument :offset, Integer, required: false
-                argument :limit, Integer, required: false
-                argument :sort_by, resource.sort_fields_enum, required: false
-                argument :sort_order, Enum::SortOrder, required: false
+              if ::HQ::GraphQL.use_experimental_associations?
+                extension FieldExtension::PaginatedArguments, klass: association_klass
+                extension FieldExtension::PaginatedLoader, klass: klass, association: name, internal_association: internal_association
+              else
+                extension FieldExtension::AssociationLoaderExtension, klass: klass
               end
+              instance_eval(&block) if block
             end
           else
-            field name, type, null: !auto_nil || !association_required?(association), klass: model_name
+            field name, type, null: !auto_nil || !association_required?(association), klass: model_name do
+              extension FieldExtension::AssociationLoaderExtension, klass: klass
+            end
           end
-        rescue ::HQ::GraphQL::Types::Error
+        rescue Types::Error
           nil
         end
 
         def field_from_column(column, auto_nil:)
-          field column.name, ::HQ::GraphQL::Types.type_from_column(column), null: !auto_nil || column.null
+          field column.name, Types.type_from_column(column), null: !auto_nil || column.null
         end
 
         def association_required?(association)

--- a/lib/hq/graphql/object_association.rb
+++ b/lib/hq/graphql/object_association.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module HQ
+  module GraphQL
+    module ObjectAssociation
+      class ResourceReflection
+        attr_reader :name, :scope, :options, :macro, :block
+
+        def initialize(name, scope, options, macro, block)
+          @name = name
+          @scope = scope
+          @options = options
+          @macro = macro
+          @block = block
+        end
+
+        def reflection(model_klass)
+          if macro == :has_many
+            ::ActiveRecord::Associations::Builder::HasMany.create_reflection(model_klass, name, scope, options)
+          elsif macro == :belongs_to
+            ::ActiveRecord::Associations::Builder::BelongsTo.create_reflection(model_klass, name, scope, options)
+          end
+        end
+      end
+
+      def reflect_on_association(association)
+        resource_reflections[association.to_s]&.reflection(model_klass)
+      end
+
+      def belongs_to(name, scope = nil, **options, &block)
+        add_reflection(name, scope, options, :belongs_to, block)
+      end
+
+      def has_many(name, scope = nil, through: nil, **options, &block)
+        raise TypeError, "has_many through is unsupported" if through
+        add_reflection(name, scope, options, :has_many, block)
+      end
+
+      private
+
+      def resource_reflections
+        @resource_reflections ||= {}
+      end
+
+      def add_reflection(name, scope, options, macro, block)
+        resource_reflections[name.to_s] = ResourceReflection.new(name, scope, options, macro, block)
+      end
+    end
+  end
+end

--- a/lib/hq/graphql/resource/auto_mutation.rb
+++ b/lib/hq/graphql/resource/auto_mutation.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "hq/graphql/inputs"
+require "hq/graphql/mutation"
+require "hq/graphql/types"
+
 module HQ
   module GraphQL
     module Resource

--- a/lib/hq/graphql/types.rb
+++ b/lib/hq/graphql/types.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "hq/graphql/types/object"
+require "hq/graphql/types/uuid"
+
 module HQ
   module GraphQL
     module Types

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.1.0"
+    VERSION = "2.1.1"
   end
 end

--- a/spec/lib/graphql/object_association_spec.rb
+++ b/spec/lib/graphql/object_association_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+describe ::HQ::GraphQL::ObjectAssociation do
+  let!(:organization_resource) do
+    Class.new do
+      include ::HQ::GraphQL::Resource
+
+      self.model_name = "Organization"
+
+      root_query
+      query do
+        has_many :custom_association, -> { where(inactive: nil) }, class_name: "User" do
+          argument :name, String, required: false
+
+          scope do |name: nil|
+            if name
+              User.where(name: name)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  let!(:user_resource) do
+    Class.new do
+      include ::HQ::GraphQL::Resource
+
+      self.model_name = "User"
+    end
+  end
+
+  let(:root_query) do
+    Class.new(::HQ::GraphQL::RootQuery)
+  end
+
+
+  let(:schema) do
+    Class.new(GraphQL::Schema) do
+      query(RootQuery)
+      use(::GraphQL::Batch)
+    end
+  end
+
+  before(:each) do
+    allow(::HQ::GraphQL.config).to receive(:use_experimental_associations) { true }
+    stub_const("RootQuery", root_query)
+    schema.to_graphql
+  end
+
+  context "meta data" do
+    it "adds a custom association field" do
+      expect(organization_resource.query_klass.fields.keys).to include("customAssociation")
+    end
+  end
+
+  context "execution" do
+    let(:organization) { ::FactoryBot.create(:organization) }
+    let!(:user1) { ::FactoryBot.create(:user, organization: organization) }
+    let!(:user2) { ::FactoryBot.create(:user, organization: organization, inactive: true) }
+    let!(:user3) { ::FactoryBot.create(:user, organization: organization) }
+
+    let(:find_organization) do
+      <<~GRAPHQL
+        query FindOrganization($id: ID!, $userName: String) {
+          organization(id: $id) {
+            id
+            customAssociation(name: $userName) {
+              id
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it "finds active users" do
+      results = schema.execute(find_organization, variables: { id: organization.id })
+      data = results["data"]["organization"]
+
+      expected = {
+        id: organization.id,
+        customAssociation: [user3, user1].map { |u| { id: u.id, name: u.name } }
+      }
+      expect(data.deep_symbolize_keys).to eql(expected)
+    end
+
+    it "finds user with a name scope" do
+      results = schema.execute(find_organization, variables: { id: organization.id, userName: user1.name })
+      data = results["data"]["organization"]
+
+      expected = {
+        id: organization.id,
+        customAssociation: [{ id: user1.id, name: user1.name }]
+      }
+      expect(data.deep_symbolize_keys).to eql(expected)
+    end
+  end
+end

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -38,6 +38,7 @@ describe ::HQ::GraphQL::Resource do
   end
 
   before(:each) do
+    allow(::HQ::GraphQL.config).to receive(:use_experimental_associations) { true }
     advisor_resource
     stub_const("RootQuery", root_query)
     stub_const("RootMutation", root_mutation)


### PR DESCRIPTION
Description
-----------
Custom associations can now be defined on graphql objects. This allows us to build scopes from graphql arguments

Example:
```ruby
class OrganizationResource
  include ::HQ::GraphQL::Resource

  self.model_name = "Organization"

  root_query
  query do
    has_many :custom_association, -> { where(inactive: nil) }, class_name: "User" do
      argument :name, String, required: false

      scope do |name: nil|
        if name
          User.where(name: name)
        end
      end
    end
  end
end
```


Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
