### PR TITLE
Allow override of default object class

### DIFF
--- a/lib/hq/graphql.rb
+++ b/lib/hq/graphql.rb
@@ -8,6 +8,10 @@ require "hq/graphql/config"
 
 module HQ
   module GraphQL
+    class << self
+      delegate :default_object_class, to: :config
+    end
+
     def self.config
       @config ||= ::HQ::GraphQL::Config.new
     end

--- a/lib/hq/graphql/active_record_extensions.rb
+++ b/lib/hq/graphql/active_record_extensions.rb
@@ -27,7 +27,7 @@ module HQ
         end
 
         def lazy_load!
-          lazy_load.map(&:call)
+          lazy_load.each(&:call)
           @lazy_load = []
         end
 

--- a/lib/hq/graphql/config.rb
+++ b/lib/hq/graphql/config.rb
@@ -5,6 +5,7 @@ module HQ
     class Config < Struct.new(
       :authorize,
       :authorize_field,
+      :default_object_class,
       :default_scope,
       :extract_class,
       :resource_lookup,

--- a/lib/hq/graphql/types.rb
+++ b/lib/hq/graphql/types.rb
@@ -13,7 +13,7 @@ module HQ
       def self.registry
         @registry ||= Hash.new do |hash, options|
           klass, nil_klass = Array(options)
-          hash[klass] = nil_klass ? nil_query_klass(klass) : klass_for(klass)
+          hash[options] = nil_klass ? nil_query_object(klass) : klass_for(klass)
         end
       end
 
@@ -61,12 +61,12 @@ module HQ
       class << self
         private
 
-        def nil_query_klass(klass_or_string)
-          find_klass(klass_or_string, :nil_query_klass)
+        def nil_query_object(klass_or_string)
+          find_klass(klass_or_string, :nil_query_object)
         end
 
         def klass_for(klass_or_string)
-          find_klass(klass_or_string, :query_klass)
+          find_klass(klass_or_string, :query_object)
         end
 
         def find_klass(klass_or_string, method)

--- a/spec/lib/graphql/object_association_spec.rb
+++ b/spec/lib/graphql/object_association_spec.rb
@@ -50,7 +50,7 @@ describe ::HQ::GraphQL::ObjectAssociation do
 
   context "meta data" do
     it "adds a custom association field" do
-      expect(organization_resource.query_klass.fields.keys).to include("customAssociation")
+      expect(organization_resource.query_object.fields.keys).to include("customAssociation")
     end
   end
 

--- a/spec/lib/graphql/resource_pagination_spec.rb
+++ b/spec/lib/graphql/resource_pagination_spec.rb
@@ -63,7 +63,7 @@ describe ::HQ::GraphQL::Resource do
   end
 
   it "adds pagination to association fields" do
-    users_field = manager_resource.query_klass.fields["users"]
+    users_field = manager_resource.query_object.fields["users"]
     users_arguments = users_field.arguments
     expect(users_field.arguments.keys).to contain_exactly(*pagination_fields)
     expect(users_arguments["sortOrder"].type).to eq HQ::GraphQL::Enum::SortOrder

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -46,7 +46,7 @@ describe ::HQ::GraphQL::Resource do
 
   context "defaults" do
     it "builds the query klass" do
-      expect(::HQ::GraphQL::Types[Advisor]).to eql(advisor_resource.query_klass)
+      expect(::HQ::GraphQL::Types[Advisor]).to eql(advisor_resource.query_object)
     end
 
     it "builds the input klass" do
@@ -54,22 +54,22 @@ describe ::HQ::GraphQL::Resource do
     end
 
     it "creates query fields" do
-      query_klass = ::HQ::GraphQL::Types[Advisor]
-      query_klass.graphql_definition
+      query_object = ::HQ::GraphQL::Types[Advisor]
+      query_object.graphql_definition
       expected = ["id", "organizationId", "name", "nickname", "createdAt", "updatedAt"]
       aggregate_failures do
-        expect(query_klass.fields.keys).to contain_exactly(*expected)
-        expect(query_klass.fields.values.map(&:type)).to be_all { |f| f.kind_of? ::GraphQL::Schema::NonNull }
+        expect(query_object.fields.keys).to contain_exactly(*expected)
+        expect(query_object.fields.values.map(&:type)).to be_all { |f| f.kind_of? ::GraphQL::Schema::NonNull }
       end
     end
 
     it "creates nil query fields" do
-      query_klass = ::HQ::GraphQL::Types[Advisor, true]
-      query_klass.graphql_definition
+      query_object = ::HQ::GraphQL::Types[Advisor, true]
+      query_object.graphql_definition
       expected = ["id", "organizationId", "name", "nickname", "createdAt", "updatedAt"]
       aggregate_failures do
-        expect(query_klass.fields.keys).to contain_exactly(*expected)
-        expect(query_klass.fields.values.map(&:type)).to be_none { |f| f.kind_of? ::GraphQL::Schema::NonNull }
+        expect(query_object.fields.keys).to contain_exactly(*expected)
+        expect(query_object.fields.values.map(&:type)).to be_none { |f| f.kind_of? ::GraphQL::Schema::NonNull }
       end
     end
 
@@ -139,6 +139,22 @@ describe ::HQ::GraphQL::Resource do
     it "customizes graphql name" do
       ::HQ::GraphQL::Types[Advisor].graphql_definition
       expect(::HQ::GraphQL::Types[Advisor].graphql_name).to eql("CustomAdvisorName")
+    end
+
+    it "overrides the default query class" do
+      new_class = Class.new(::HQ::GraphQL::Object)
+      advisor_resource.class_eval do
+        query_class new_class
+      end
+
+      expect(advisor_resource.query_object.superclass).to be(new_class)
+    end
+
+    it "overrides the global query class" do
+      new_class = Class.new(::HQ::GraphQL::Object)
+      allow(::HQ::GraphQL.config).to receive(:default_object_class) { new_class }
+
+      expect(advisor_resource.query_object.superclass).to be(new_class)
     end
   end
 

--- a/spec/lib/graphql/types_spec.rb
+++ b/spec/lib/graphql/types_spec.rb
@@ -15,7 +15,7 @@ describe ::HQ::GraphQL::Types do
       end
     end
 
-    let(:type_object) { graphql_klass.query_klass }
+    let(:type_object) { graphql_klass.query_object }
 
     before(:each) do
       graphql_klass
@@ -44,7 +44,7 @@ describe ::HQ::GraphQL::Types do
         include ::HQ::GraphQL::Resource
         self.model_name = "Agent"
       end
-      expect(sti_resource.query_klass).to eql(described_class["Agent"])
+      expect(sti_resource.query_object).to eql(described_class["Agent"])
     end
 
     it "falls back to the base class" do


### PR DESCRIPTION
Description
-----------
Allow override of the default object class. This will allow us to create a parent class that defines default logic on our queries.

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
- [ ] If this PR has a jira ticket, I used a [JIRA smart commit](https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html) to link the ticket to this PR.
