### PR TITLE
[AN-288] Allow "input inheritance" to reuse arguments

### DIFF
--- a/lib/hq/graphql/input_object.rb
+++ b/lib/hq/graphql/input_object.rb
@@ -60,6 +60,12 @@ module HQ
         super
       end
 
+      def self.extends(input_object)
+        input_object.arguments.each do |arg, properties|
+          argument arg.to_sym, properties.graphql_definition.type, required: properties.type.non_null?
+        end
+      end
+
       class << self
         private
 

--- a/lib/hq/graphql/input_object.rb
+++ b/lib/hq/graphql/input_object.rb
@@ -61,8 +61,8 @@ module HQ
       end
 
       def self.extends(input_object)
-        input_object.arguments.each do |arg, properties|
-          argument arg.to_sym, properties.graphql_definition.type, required: properties.type.non_null?
+        input_object.arguments.each do |_arg, properties|
+          add_argument(properties)
         end
       end
 

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.1.10"
+    VERSION = "2.1.11"
   end
 end

--- a/spec/lib/graphql/input_object_spec.rb
+++ b/spec/lib/graphql/input_object_spec.rb
@@ -108,6 +108,28 @@ describe ::HQ::GraphQL::InputObject do
       end
     end
 
+    describe ".extends" do
+      it "keeps all arguments and adds arguments from extended class" do
+        class LinkedUserInput < GraphQL::Schema::InputObject
+          argument :form_linked_user_id, ID, required: false
+          argument :is_linked_user_form_update, String, required: false
+        end
+
+        hq_input_object.class_eval do
+          extends LinkedUserInput
+          with_model "Advisor"
+        end
+
+        hq_input_object.graphql_definition
+        expected = %w[formLinkedUserId isLinkedUserFormUpdate createdAt id name nickname organizationId updatedAt X]
+        expect(hq_input_object.arguments.keys).to contain_exactly(*expected)
+
+        LinkedUserInput.arguments.each do |arg, properties|
+          expect(hq_input_object.arguments[arg]).to be(properties)
+        end
+      end
+    end
+
     context "with attributes and associations turned off" do
       it "doesn't have any arguments by default" do
         hq_input_object.graphql_definition


### PR DESCRIPTION
Description
-----------
Added `extends` method to `input_object` to add all the arguments from another input object. Check this line for usage https://github.com/OneHQ/agencieshq/pull/13773/files#diff-4f4041aed4331f48e3a88b8d620b8630R42

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
