### PR TITLE
Custom scalars accept nil input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Bug fixes
 
+# 2.2.2 (12 February 2021)
+
+### Bug fixes
+
+- UUID scalar supports nil input. This is related to a change introduced in graphql-ruby v1.10 in which `.coerce_input` is called on nil values.
+
 # 2.2.1 (04 February 2021)
 
 ### Bug fixes

--- a/lib/hq/graphql/types/uuid.rb
+++ b/lib/hq/graphql/types/uuid.rb
@@ -26,7 +26,7 @@ module HQ
           end
 
           def validate_uuid(value)
-            !!value.to_s.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+            !value || !!value.to_s.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
           end
         end
       end

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.2.1"
+    VERSION = "2.2.2"
   end
 end


### PR DESCRIPTION
Description
-----------
### Bug fixes

- UUID scalar supports nil input. This is related to a change introduced in graphql-ruby v1.10 in which `.coerce_input` is called on nil values.

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [X] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
