### PR TITLE
[AN-848] - Fix date type issue

### DIFF
--- a/lib/hq/graphql/types.rb
+++ b/lib/hq/graphql/types.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "hq/graphql/types/uuid"
+require "hq/graphql/types/date_type"
 
 module HQ
   module GraphQL
@@ -42,7 +43,7 @@ module HQ
           when :boolean
             ::GraphQL::Types::Boolean
           when :date
-            ::GraphQL::Types::ISO8601Date
+            ::Types::DateType
           when :datetime
             ::GraphQL::Types::ISO8601DateTime
           else

--- a/lib/hq/graphql/types/date_type.rb
+++ b/lib/hq/graphql/types/date_type.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  class DateType < GraphQL::Schema::Scalar
+    # https://github.com/rmosolgo/graphql-ruby/issues/2117
+    # https://github.com/rmosolgo/graphql-ruby-demo/issues/27
+    def self.coerce_input(input_value, _context)
+      if input_value.instance_of? String
+        Date.iso8601(input_value)
+      else
+        input_value
+      end
+    rescue ArgumentError
+      nil
+    end
+
+    def self.coerce_result(ruby_value, _context)
+      ruby_value.iso8601
+    end
+  end
+end

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.2.4"
+    VERSION = "2.2.5"
   end
 end

--- a/spec/lib/graphql/types_spec.rb
+++ b/spec/lib/graphql/types_spec.rb
@@ -101,7 +101,7 @@ describe ::HQ::GraphQL::Types do
 
     context "Date" do
       it "matches iso date" do
-        expect(type_from_column("created_date")).to eq ::GraphQL::Types::ISO8601Date
+        expect(type_from_column("created_date")).to eq ::Types::DateType
       end
     end
 


### PR DESCRIPTION
Description
-----------
This provides a fix for the cached date type issue, using a custom `date` type.

### Error
`Could not coerce value "2021-10-18" to ISO8601Date`

### Example
![Screen Shot 2021-10-18 at 15 45 00](https://user-images.githubusercontent.com/4020310/137788741-d58d57ec-e494-4c0b-9fd4-981157d6f85d.png)

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
