### PR TITLE
[PD-10568] New Resource Queries

### DIFF
--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -152,12 +152,18 @@ module HQ
           @input_klass = build_input_object(**options, &block)
         end
 
+        # mutations generates available default mutations on RootMutation for a certain resource
+        # Parameters:
+        # create => adds create operation
+        # copy => adds copy operation
+        # update => adds update operation
+        # destroy => adds destroy operation
         def mutations(create: true, copy: true, update: true, destroy: true)
           scoped_self = self
           if create
             mutation_klasses["create_#{graphql_name.underscore}"] = build_create
-
-            def_root "hydrate_#{graphql_name.underscore}", is_array: false, null: true, hydrate: true do
+            # new_resource query will be created only if create mutation is created
+            def_root "new_#{graphql_name.underscore}", is_array: false, null: true, new_query: true do
               klass = scoped_self.model_klass
 
               define_method(:resolve) do
@@ -186,13 +192,22 @@ module HQ
           @excluded_inputs = fields
         end
 
-        def def_root(field_name, is_array: false, pagination: true, null: true, hydrate: false, &block)
+        # def_root generates available queries on RootQuery
+        # this method can be used to create resource's custom queries
+        # Parameters:
+        # field_name => operation name in RootQuery
+        # is_array => if true, creates List query. false for single record query.
+        # null => sets if result can be null.
+        # new_query it's only used to stablish the correct Object type that must be configured in the resolver.
+        # new_query is necessary because the same block of code is used to create getById and new_resource queries.
+        # block => code block that it's going to be executed to get the result.
+        def def_root(field_name, is_array: false, null: true, new_query: false, &block)
           resource = self
           suffix = is_array ? "List" : ""
           if is_array
             connection_resolver = -> {
               klass = Class.new(::GraphQL::Schema::Resolver) do
-                type = pagination ? resource.query_object.connection_type : [resource.query_object]
+                type = resource.query_object.connection_type
 
                 type type, null: null
                 class_eval(&block) if block
@@ -208,7 +223,7 @@ module HQ
           else
             resolver = -> {
               klass = Class.new(::GraphQL::Schema::Resolver) do
-                type = hydrate ? resource.nil_query_object : resource.query_object
+                type = new_query ? resource.nil_query_object : resource.query_object
                 type type, null: null
                 class_eval(&block) if block
               end
@@ -223,7 +238,12 @@ module HQ
           end
         end
 
-        def root_query(find_one: true, find_all: true, pagination: true, limit_max: 250)
+        # root_query generates available default queries on RootQuery for a certain resource
+        # Parameters:
+        # find_one => getById query
+        # find_all => list query
+        # limit_max => max amount of record that can be obtained
+        def root_query(find_one: true, find_all: true, limit_max: 250)
           field_name = graphql_name.underscore
           scoped_self = self
 
@@ -241,8 +261,8 @@ module HQ
           end
 
           if find_all
-            def_root field_name.pluralize, is_array: true, pagination: pagination, null: false do
-              extension FieldExtension::PaginatedArguments, klass: scoped_self.model_klass if pagination
+            def_root field_name.pluralize, is_array: true, null: false do
+              extension FieldExtension::PaginatedArguments, klass: scoped_self.model_klass
               argument :filters, [scoped_self.filter_input], required: false
 
               define_method(:resolve) do |filters: nil, limit: nil, offset: nil, sort_by: nil, sort_order: nil, **_attrs|
@@ -251,11 +271,9 @@ module HQ
 
                 scope = scoped_self.scope(context).all.merge(filters_scope.to_scope)
 
-                if pagination || limit
-                  offset = [0, *offset].max
-                  limit = [[limit_max, *limit].min, 0].max
-                  scope = scope.limit(limit).offset(offset)
-                end
+                offset = [0, *offset].max
+                limit = [[limit_max, *limit].min, 0].max
+                scope = scope.limit(limit).offset(offset)
 
                 sort_by ||= :updated_at
                 sort_order ||= :desc

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.3.2"
+    VERSION = "2.3.3"
   end
 end

--- a/spec/lib/graphql/filters_spec.rb
+++ b/spec/lib/graphql/filters_spec.rb
@@ -26,7 +26,7 @@ describe ::HQ::GraphQL::Filters do
   let(:query) { <<-GRAPHQL
       query findTestTypes($filters: [TestTypeQueryFilterInput!]) {
         testTypes(filters: $filters) {
-          testTypes {
+          nodes {
             id
           }
         }
@@ -49,21 +49,21 @@ describe ::HQ::GraphQL::Filters do
 
     it "filters test_types using WITH" do
       results = schema.execute(query, variables: { filters: [{ field: "isBool", operation: "WITH", value: "t" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
 
     it "filters test_types using WITH(out)" do
       results = schema.execute(query, variables: { filters: [{ field: "isBool", operation: "WITH", value: "f" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 10
       expect(data.map { |d| d["id"] }).to contain_exactly(*test_types.map(&:id))
     end
 
     it "filters test_types using OR statement" do
       results = schema.execute(query, variables: { filters: [{ field: "isBool", operation: "WITH", value: "t" }, { field: "isBool", operation: "WITH", value: "f", isOr: true }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 11
       expect(data.map { |d| d["id"] }).to contain_exactly(*(test_types + [target]).map(&:id))
     end
@@ -90,21 +90,21 @@ describe ::HQ::GraphQL::Filters do
 
     it "filters test_types using GREATER_THAN" do
       results = schema.execute(query, variables: { filters: [{ field: "createdAt", operation: "GREATER_THAN", value: target.created_at.iso8601 }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
 
     it "filters test_types using LESS_THAN" do
       results = schema.execute(query, variables: { filters: [{ field: "createdAt", operation: "LESS_THAN", value: target.created_at.iso8601 }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 10
       expect(data.map { |d| d["id"] }).to contain_exactly(*test_types.map(&:id))
     end
 
     it "filters test_types using OR statement" do
       results = schema.execute(query, variables: { filters: [{ field: "createdAt", operation: "GREATER_THAN", value: target.created_at.iso8601 }, { field: "createdAt", operation: "LESS_THAN", value: target.created_at.iso8601, isOr: true }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 11
       expect(data.map { |d| d["id"] }).to contain_exactly(*(test_types + [target]).map(&:id))
     end
@@ -132,14 +132,14 @@ describe ::HQ::GraphQL::Filters do
 
     it "filters test_types using GREATER_THAN" do
       results = schema.execute(query, variables: { filters: [{ field: "count", operation: "GREATER_THAN", value: "10" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
 
     it "filters test_types using LESS_THAN" do
       results = schema.execute(query, variables: { filters: [{ field: "count", operation: "LESS_THAN", value: "10" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 10
       expect(data.map { |d| d["id"] }).to contain_exactly(*test_types.map(&:id))
     end
@@ -147,21 +147,21 @@ describe ::HQ::GraphQL::Filters do
     it "filters test_types using EQUAL" do
       target = test_types.sample
       results = schema.execute(query, variables: { filters: [{ field: "count", operation: "EQUAL", value: target.count.to_s }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
 
     it "filters test_types using NOT_EQUAL" do
       results = schema.execute(query, variables: { filters: [{ field: "count", operation: "NOT_EQUAL", value: target.count.to_s }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 10
       expect(data.map { |d| d["id"] }).to contain_exactly(*test_types.map(&:id))
     end
 
     it "filters test_types comparing columns" do
       results = schema.execute(query, variables: { filters: [{ field: "count", operation: "EQUAL", columnValue: "count" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 11
     end
 
@@ -172,7 +172,7 @@ describe ::HQ::GraphQL::Filters do
         { field: "count", operation: "EQUAL", value: target_two.count.to_s, isOr: true},
         { field: "count", operation: "IN", arrayValues: [target.count.to_s, target_two.count.to_s], isOr: true }
         ]})
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 2
       expect(data[0]["id"]).to eql(target_two.id)
       expect(data[1]["id"]).to eql(target.id)
@@ -201,14 +201,14 @@ describe ::HQ::GraphQL::Filters do
 
     it "filters test_types using EQUAL" do
       results = schema.execute(query, variables: { filters: [{ field: "name", operation: "EQUAL", value: target.name }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
 
     it "filters test_types using NOT_EQUAL" do
       results = schema.execute(query, variables: { filters: [{ field: "name", operation: "NOT_EQUAL", value: target.name }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 10
       expect(data.map { |d| d["id"] }).to contain_exactly(*test_types.map(&:id))
     end
@@ -216,7 +216,7 @@ describe ::HQ::GraphQL::Filters do
     it "filters test_types using IN" do
       target_two = TestType.create(name: "Unique Name Two")
       results = schema.execute(query, variables: { filters: [{ field: "name", operation: "IN", arrayValues: [target.name, target_two.name] }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 2
       expect(data[0]["id"]).to eql(target_two.id)
       expect(data[1]["id"]).to eql(target.id)
@@ -224,21 +224,21 @@ describe ::HQ::GraphQL::Filters do
 
     it "filters test_types using LIKE" do
       results = schema.execute(query, variables: { filters: [{ field: "name", operation: "LIKE", value: "unique" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
 
     it "filters test_types using NOT_LIKE" do
       results = schema.execute(query, variables: { filters: [{ field: "name", operation: "NOT_LIKE", value: "unique" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 10
       expect(data.map { |d| d["id"] }).to contain_exactly(*test_types.map(&:id))
     end
 
     it "filters test_types comparing columns" do
       results = schema.execute(query, variables: { filters: [{ field: "name", operation: "EQUAL", columnValue: "name" }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
@@ -250,7 +250,7 @@ describe ::HQ::GraphQL::Filters do
         { field: "name", operation: "EQUAL", value: target_two.name, isOr: true},
         { field: "name", operation: "IN", arrayValues: [target.name, target_two.name], isOr: true }
         ]})
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 2
       expect(data[0]["id"]).to eql(target_two.id)
       expect(data[1]["id"]).to eql(target.id)
@@ -271,14 +271,14 @@ describe ::HQ::GraphQL::Filters do
 
     it "filters test_types using EQUAL" do
       results = schema.execute(query, variables: { filters: [{ field: "id", operation: "EQUAL", value: target.id }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 1
       expect(data[0]["id"]).to eql(target.id)
     end
 
     it "filters test_types using NOT_EQUAL" do
       results = schema.execute(query, variables: { filters: [{ field: "id", operation: "NOT_EQUAL", value: target.id }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 10
       expect(data.map { |d| d["id"] }).to contain_exactly(*test_types.map(&:id))
     end
@@ -286,7 +286,7 @@ describe ::HQ::GraphQL::Filters do
     it "filters test_types using IN" do
       target_two = TestType.create
       results = schema.execute(query, variables: { filters: [{ field: "id", operation: "IN", arrayValues: [target.id, target_two.id] }] })
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data[0]["id"]).to eql(target_two.id)
       expect(data[1]["id"]).to eql(target.id)
     end
@@ -298,7 +298,7 @@ describe ::HQ::GraphQL::Filters do
         { field: "id", operation: "EQUAL", value: target_two.id, isOr: true},
         { field: "id", operation: "IN", arrayValues: [target.id, target_two.id], isOr: true }
         ]})
-      data = results["data"]["testTypes"]["testTypes"]
+      data = results["data"]["testTypes"]["nodes"]
       expect(data.length).to be 2
       expect(data[0]["id"]).to eql(target_two.id)
       expect(data[1]["id"]).to eql(target.id)

--- a/spec/lib/graphql/pagination_connection_type_spec.rb
+++ b/spec/lib/graphql/pagination_connection_type_spec.rb
@@ -31,9 +31,6 @@ describe ::HQ::GraphQL::PaginationConnectionType do
           nodes {
             id
           }
-          testTypes{
-            id
-          }
           edges {
             cursor
             node{
@@ -109,14 +106,6 @@ describe ::HQ::GraphQL::PaginationConnectionType do
       results = schema.execute(query, variables: { first: 2, before: cursor, sortOrder: "ASC" })
       advisors = results["data"]["testTypes"]["nodes"].pluck("id")
       expect(advisors).to eq test_types.first(1).map(&:id)
-    end
-  end
-  context "total elements" do
-    it "totalCount equal to testTypes size" do
-      results = schema.execute(query, variables: { first: 2, sortOrder: "ASC" })
-      advisors = results["data"]["testTypes"]["testTypes"]
-      totalCount = results["data"]["testTypes"]["totalCount"]
-      expect(advisors.length).to eq totalCount
     end
   end
 end

--- a/spec/lib/graphql/resource_pagination_spec.rb
+++ b/spec/lib/graphql/resource_pagination_spec.rb
@@ -48,7 +48,7 @@ describe ::HQ::GraphQL::Resource do
   end
 
   it "adds pagination to the root query and pagination queries" do
-    expect(root_fields.keys).to contain_exactly("manager", "managers", "user", "users")
+    expect(root_fields.keys).to contain_exactly("manager", "managers", "hydrateManager", "user", "users", "hydrateUser")
     expect(managers_arguments.keys).to contain_exactly(*query_fields)
     expect(users_arguments.keys).to contain_exactly(*query_fields)
   end

--- a/spec/lib/graphql/resource_pagination_spec.rb
+++ b/spec/lib/graphql/resource_pagination_spec.rb
@@ -50,7 +50,7 @@ describe ::HQ::GraphQL::Resource do
   end
 
   it "adds pagination to the root query and pagination queries" do
-    expect(root_fields.keys).to contain_exactly("manager", "managers", "hydrateManager", "user", "users", "hydrateUser")
+    expect(root_fields.keys).to contain_exactly("manager", "managers", "newManager", "user", "users", "newUser")
     expect(managers_arguments.keys).to contain_exactly(*query_fields)
     expect(users_arguments.keys).to contain_exactly(*query_fields)
   end

--- a/spec/lib/graphql/resource_pagination_spec.rb
+++ b/spec/lib/graphql/resource_pagination_spec.rb
@@ -7,6 +7,7 @@ describe ::HQ::GraphQL::Resource do
       self.model_name = "Manager"
 
       root_query
+      mutations
     end
   end
 
@@ -18,6 +19,7 @@ describe ::HQ::GraphQL::Resource do
       sort_fields :name
 
       root_query
+      mutations
     end
   end
 

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -390,9 +390,9 @@ describe ::HQ::GraphQL::Resource do
       GRAPHQL
     }
 
-    let(:hydrate_advisor) { <<-GRAPHQL
-        query hydrateAdvisor {
-          hydrateAdvisor {
+    let(:new_advisor) { <<-GRAPHQL
+        query newAdvisor {
+          newAdvisor {
             name
             organizationId
           }
@@ -480,9 +480,9 @@ describe ::HQ::GraphQL::Resource do
       end
     end
 
-    it "uses hydrate" do
-      results = schema.execute(hydrate_advisor)
-      data = results["data"]["hydrateAdvisor"]
+    it "uses new" do
+      results = schema.execute(new_advisor)
+      data = results["data"]["newAdvisor"]
       expect(data.length).to be 2
     end
 

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -235,7 +235,7 @@ describe ::HQ::GraphQL::Resource do
     let(:find_onehq) { <<-GRAPHQL
         query advisorsNamedOneHq {
           advisorsNamedOneHq {
-            advisorsNamedOneHq {
+            nodes {
               name
               organizationId
 
@@ -264,7 +264,7 @@ describe ::HQ::GraphQL::Resource do
       FactoryBot.create(:advisor)
       onehq = FactoryBot.create(:advisor, name: "OneHQ")
       results = schema.execute(find_onehq)
-      data = results["data"]["advisorsNamedOneHq"]["advisorsNamedOneHq"]
+      data = results["data"]["advisorsNamedOneHq"]["nodes"]
       expect(data.size).to eq 1
       advisor = data[0]
 
@@ -337,7 +337,7 @@ describe ::HQ::GraphQL::Resource do
     let(:find_advisors) { <<-GRAPHQL
         query findAdvisors($limit: Int) {
           advisors(limit: $limit) {
-            advisors {
+            nodes {
               name
               organizationId
               organization {
@@ -427,7 +427,7 @@ describe ::HQ::GraphQL::Resource do
     it "uses pagination" do
       10.times { FactoryBot.create(:advisor) }
       results = schema.execute(find_advisors, variables: { limit: 5 })
-      data = results["data"]["advisors"]["advisors"]
+      data = results["data"]["advisors"]["nodes"]
       expect(data.length).to be 5
     end
 

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -390,6 +390,16 @@ describe ::HQ::GraphQL::Resource do
       GRAPHQL
     }
 
+    let(:hydrate_advisor) { <<-GRAPHQL
+        query hydrateAdvisor {
+          hydrateAdvisor {
+            name
+            organizationId
+          }
+        }
+      GRAPHQL
+    }
+
     before(:each) do
       organization_type
 
@@ -468,6 +478,12 @@ describe ::HQ::GraphQL::Resource do
         expect(data["destroyAdvisor"]["resource"]["name"]).to eql advisor.name
         expect(Advisor.where(id: advisor.id).exists?).to eql false
       end
+    end
+
+    it "uses hydrate" do
+      results = schema.execute(hydrate_advisor)
+      data = results["data"]["hydrateAdvisor"]
+      expect(data.length).to be 2
     end
 
     context "with authorization" do


### PR DESCRIPTION
Description
-----------
By default, New Queries will be generated if Create Mutation is available. These queries will be useful for forms init. Default values will be based on methods applied using after_initialize callback on model.

Advisor New Query Example:
```
{
  newAdvisor {
    name
    advisor_status_id
    demographic {
      id
      ...
    }
  }
}

Also in this version, property to access to the list without pagination is removed. Now the list can be retrieved using nodes or edges properties.

{
  Advisor {
    ...
    nodes {
      id
      ...
    }
    edges {
      id
      node {
        id
        ...
      }
      ...
    }
  }
}
```
Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
