### PR TITLE
[PD-11144] - Remove limit_max restrictions when first/last is provided on root_query

### DIFF
--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -242,7 +242,7 @@ module HQ
         # Parameters:
         # find_one => getById query
         # find_all => list query
-        # limit_max => max amount of record that can be obtained
+        # limit_max => max amount of record that can be obtained if 'first' is not provided
         def root_query(find_one: true, find_all: true, limit_max: 250)
           field_name = graphql_name.underscore
           scoped_self = self
@@ -270,11 +270,16 @@ module HQ
                 filters_scope.validate!
 
                 scope = scoped_self.scope(context).all.merge(filters_scope.to_scope)
-
                 offset = [0, *offset].max
-                limit = [[limit_max, *limit].min, 0].max
-                scope = scope.limit(limit).offset(offset)
 
+                # set limit_max if first N is not provided                
+                scope = if limit.present? || !context.query.provided_variables.key?("first")
+                  limit = [[limit_max, *limit].min, 0].max
+                  scope.limit(limit).offset(offset)
+                else
+                  scope.offset(offset)
+                end
+                
                 sort_by ||= :updated_at
                 sort_order ||= :desc
                 # There should be no risk for SQL injection since an enum is being used for both sort_by and sort_order

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -273,7 +273,7 @@ module HQ
                 offset = [0, *offset].max
 
                 # set limit_max if first/last N is not provided
-                scope = if limit.present? || !(context.query.provided_variables.keys & [:first, :last]).any?
+                scope = if limit.present? || !(context.query.provided_variables.symbolize_keys.keys & [:first, :last]).any?
                   limit = [[limit_max, *limit].min, 0].max
                   scope.limit(limit).offset(offset)
                 else

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -242,7 +242,7 @@ module HQ
         # Parameters:
         # find_one => getById query
         # find_all => list query
-        # limit_max => max amount of record that can be obtained if 'first' is not provided
+        # limit_max => max amount of record that can be obtained if 'first/last' is not provided
         def root_query(find_one: true, find_all: true, limit_max: 250)
           field_name = graphql_name.underscore
           scoped_self = self
@@ -272,8 +272,8 @@ module HQ
                 scope = scoped_self.scope(context).all.merge(filters_scope.to_scope)
                 offset = [0, *offset].max
 
-                # set limit_max if first N is not provided                
-                scope = if limit.present? || !context.query.provided_variables.key?("first")
+                # set limit_max if first/last N is not provided
+                scope = if limit.present? || !(context.query.provided_variables.keys & [:first, :last]).any?
                   limit = [[limit_max, *limit].min, 0].max
                   scope.limit(limit).offset(offset)
                 else

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.3.3"
+    VERSION = "2.3.4"
   end
 end

--- a/spec/lib/graphql/pagination_connection_type_spec.rb
+++ b/spec/lib/graphql/pagination_connection_type_spec.rb
@@ -21,7 +21,7 @@ describe ::HQ::GraphQL::PaginationConnectionType do
     end
   end
 
-  let!(:test_types) { 10.times.map { |i| TestType.create(created_at: 1.year.ago, count: i) } }
+  let!(:test_types) { 252.times.map { |i| TestType.create(created_at: 1.year.ago, count: i) } }
 
   let(:query) { <<-GRAPHQL
       query findTestTypes($before: String, $after: String, $first: Int, $last: Int, $sortOrder: SortOrder) {
@@ -59,7 +59,13 @@ describe ::HQ::GraphQL::PaginationConnectionType do
       advisors = results["data"]["testTypes"]["nodes"].pluck("id")
       expect(advisors).to eq test_types.first(2).map(&:id)
     end
-
+    it "first 2, with totalCount > limit_max" do
+      results = schema.execute(query, variables: { first: 2, sortOrder: "ASC" })
+      data = results["data"]["testTypes"]["nodes"]
+      totalCount = results["data"]["testTypes"]["totalCount"]
+      expect(data.length).to be 2
+      expect(totalCount).to be 252
+    end
     it "last 1" do
       results = schema.execute(query, variables: { last: 1, sortOrder: "ASC" })
       advisors = results["data"]["testTypes"]["nodes"].pluck("id")
@@ -71,7 +77,16 @@ describe ::HQ::GraphQL::PaginationConnectionType do
       advisors = results["data"]["testTypes"]["nodes"].pluck("id")
       expect(advisors).to eq test_types.last(2).map(&:id)
     end
+
+    it "last 2, with totalCount > limit_max" do
+      results = schema.execute(query, variables: { last: 2, sortOrder: "ASC" })
+      data = results["data"]["testTypes"]["nodes"]
+      totalCount = results["data"]["testTypes"]["totalCount"]
+      expect(data.length).to be 2
+      expect(totalCount).to be 252
+    end
   end
+
   context "after" do
     it "first 2, after 2 element cursor" do
       results = schema.execute(query, variables: { first: 2, sortOrder: "ASC" })

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -431,6 +431,13 @@ describe ::HQ::GraphQL::Resource do
       expect(data.length).to be 5
     end
 
+    it "set limit_max if limit is not provided" do
+      251.times { FactoryBot.create(:advisor) }
+      results = schema.execute(find_advisors, variables: {})
+      data = results["data"]["advisors"]["nodes"]
+      expect(data.length).to be 250
+    end
+
     it "creates" do
       organization = FactoryBot.create(:organization)
       name = "Bob"

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -431,7 +431,7 @@ describe ::HQ::GraphQL::Resource do
       expect(data.length).to be 5
     end
 
-    it "set limit_max if limit is not provided" do
+    it "set limit_max if limit/first is not provided" do
       251.times { FactoryBot.create(:advisor) }
       results = schema.execute(find_advisors, variables: {})
       data = results["data"]["advisors"]["nodes"]


### PR DESCRIPTION
Description
-----------
- Fix totalCount, it was limited to 250.
- Remove limit_max restriction if the query contains first/last params.

## Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
| ** original screenshot ** | ** updated screenshot ** |
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/11179713/222510625-34c1c9f6-f789-4280-9ef4-b47a7dfd478a.png"> | <img width="1728" alt="image" src="https://user-images.githubusercontent.com/11179713/222510386-a0fc3a98-e3c3-4bf6-98c4-2064cd2fe4cc.png">

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [x] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
