### PR TITLE
[PD-11928] Add Initial Parameters To New Resource Query

### DIFF
--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -162,19 +162,19 @@ module HQ
           scoped_self = self
           if create
             mutation_klasses["create_#{graphql_name.underscore}"] = build_create
-            # new_resource query will be created only if create mutation is created
+            # new_resource query will be created only if create mutation is created and hydrate method exist
+            klass = scoped_self.model_klass
             def_root "new_#{graphql_name.underscore}", is_array: false, null: true, new_query: true do
-              klass = scoped_self.model_klass
               input_object = scoped_self.input_klass
 
               argument :attributes, input_object, required: false
 
               define_method(:resolve) do |**attrs|
                 resource_instance = klass.new(attrs[:attributes].to_h)
-                resource_instance.valid?
+                resource_instance.hydrate
                 resource_instance
               end
-            end
+            end if klass.method_defined? :hydrate
           end
           mutation_klasses["copy_#{graphql_name.underscore}"] = build_copy if copy
           mutation_klasses["update_#{graphql_name.underscore}"] = build_update if update

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -165,9 +165,14 @@ module HQ
             # new_resource query will be created only if create mutation is created
             def_root "new_#{graphql_name.underscore}", is_array: false, null: true, new_query: true do
               klass = scoped_self.model_klass
+              input_object = scoped_self.input_klass
 
-              define_method(:resolve) do
-                klass.new
+              argument :attributes, input_object, required: false
+
+              define_method(:resolve) do |**attrs|
+                resource_instance = klass.new(attrs[:attributes].to_h)
+                resource_instance.valid?
+                resource_instance
               end
             end
           end
@@ -279,7 +284,7 @@ module HQ
                 else
                   scope.offset(offset)
                 end
-                
+
                 sort_by ||= :updated_at
                 sort_order ||= :desc
                 # There should be no risk for SQL injection since an enum is being used for both sort_by and sort_order

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -162,7 +162,7 @@ module HQ
           scoped_self = self
           if create
             mutation_klasses["create_#{graphql_name.underscore}"] = build_create
-            # new_resource query will be created only if create mutation is created and hydrate method exist
+            # new_resource query will be created only if create mutation exist
             klass = scoped_self.model_klass
             def_root "new_#{graphql_name.underscore}", is_array: false, null: true, new_query: true do
               input_object = scoped_self.input_klass
@@ -174,7 +174,7 @@ module HQ
                 resource_instance.hydrate
                 resource_instance
               end
-            end if klass.method_defined? :hydrate
+            end
           end
           mutation_klasses["copy_#{graphql_name.underscore}"] = build_copy if copy
           mutation_klasses["update_#{graphql_name.underscore}"] = build_update if update

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.3.4"
+    VERSION = "2.3.5"
   end
 end

--- a/spec/internal/app/models/advisor.rb
+++ b/spec/internal/app/models/advisor.rb
@@ -1,3 +1,6 @@
 class Advisor < ActiveRecord::Base
   belongs_to :organization
+
+  def hydrate
+  end
 end

--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -2,4 +2,7 @@ class User < ::ActiveRecord::Base
   belongs_to :advisor, optional: true
   belongs_to :manager, optional: true
   belongs_to :organization
+
+  def hydrate
+  end
 end

--- a/spec/lib/graphql/resource_pagination_spec.rb
+++ b/spec/lib/graphql/resource_pagination_spec.rb
@@ -50,7 +50,7 @@ describe ::HQ::GraphQL::Resource do
   end
 
   it "adds pagination to the root query and pagination queries" do
-    expect(root_fields.keys).to contain_exactly("manager", "managers", "user", "users", "newUser")
+    expect(root_fields.keys).to contain_exactly("manager", "managers", "newManager", "user", "users", "newUser")
     expect(managers_arguments.keys).to contain_exactly(*query_fields)
     expect(users_arguments.keys).to contain_exactly(*query_fields)
   end

--- a/spec/lib/graphql/resource_pagination_spec.rb
+++ b/spec/lib/graphql/resource_pagination_spec.rb
@@ -50,7 +50,7 @@ describe ::HQ::GraphQL::Resource do
   end
 
   it "adds pagination to the root query and pagination queries" do
-    expect(root_fields.keys).to contain_exactly("manager", "managers", "newManager", "user", "users", "newUser")
+    expect(root_fields.keys).to contain_exactly("manager", "managers", "user", "users", "newUser")
     expect(managers_arguments.keys).to contain_exactly(*query_fields)
     expect(users_arguments.keys).to contain_exactly(*query_fields)
   end


### PR DESCRIPTION
Description
-----------
Hydrate Queries will execute validations instead of after_initialize callback
Hydrate Queries will accept initial parameters before run validations

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
