### PR TITLE
[PD-12052] Nil inputs implementation and specs

### DIFF
--- a/lib/hq/graphql.rb
+++ b/lib/hq/graphql.rb
@@ -56,6 +56,7 @@ module HQ
       @enums = nil
       @resources = nil
       ::HQ::GraphQL::Inputs.reset!
+      ::HQ::GraphQL::NilInputs.reset!
       ::HQ::GraphQL::Types.reset!
     end
 
@@ -90,6 +91,7 @@ require "hq/graphql/scalars"
 require "hq/graphql/comparator"
 require "hq/graphql/ext"
 require "hq/graphql/inputs"
+require "hq/graphql/nil_inputs"
 require "hq/graphql/paginated_association_loader"
 require "hq/graphql/record_loader"
 require "hq/graphql/resource"

--- a/lib/hq/graphql/ext/active_record_extensions.rb
+++ b/lib/hq/graphql/ext/active_record_extensions.rb
@@ -72,21 +72,6 @@ module HQ
 
           private
 
-          #method that handles arguments addition for reosurce inputs and resource's hydrate Inputs
-          #attrs: two element array of arrays
-          #first element: input's name
-          #second element: input's type
-          #returns required or not required arguments checking if graphql_name contains the substring 'NilInput'
-          def add_required_arguments(*attrs)
-            validate_model!
-            graphql_name = self.graphql_name
-            return attrs.map { |el| argument el[0], el[1], required: false } if graphql_name.include? "NilInput"
-            attrs.map { |el| argument el[0], el[1], required: true }
-          end
-          alias_method :add_required_argument, :add_required_arguments
-          alias_method :add_req_args, :add_required_arguments
-          alias_method :add_req_arg, :add_required_arguments
-
           def add_attributes(*attrs)
             validate_model!
             added_attributes.concat attrs.map(&:to_sym)

--- a/lib/hq/graphql/ext/active_record_extensions.rb
+++ b/lib/hq/graphql/ext/active_record_extensions.rb
@@ -72,6 +72,21 @@ module HQ
 
           private
 
+          #method that handles arguments addition for reosurce inputs and resource's hydrate Inputs
+          #attrs: two element array of arrays
+          #first element: input's name
+          #second element: input's type
+          #returns required or not required arguments checking if graphql_name contains the substring 'NilInput'
+          def add_required_arguments(*attrs)
+            validate_model!
+            graphql_name = self.graphql_name
+            return attrs.map { |el| argument el[0], el[1], required: false } if graphql_name.include? "NilInput"
+            attrs.map { |el| argument el[0], el[1], required: true }
+          end
+          alias_method :add_required_argument, :add_required_arguments
+          alias_method :add_req_args, :add_required_arguments
+          alias_method :add_req_arg, :add_required_arguments
+
           def add_attributes(*attrs)
             validate_model!
             added_attributes.concat attrs.map(&:to_sym)

--- a/lib/hq/graphql/ext/input_object_extensions.rb
+++ b/lib/hq/graphql/ext/input_object_extensions.rb
@@ -41,7 +41,7 @@ module HQ
 
         module ClassMethods
           #### Class Methods ####
-          def with_model(model_name, attributes: true, associations: false, enums: true, excluded_inputs: [])
+          def with_model(model_name, attributes: true, associations: false, auto_nil: nil, enums: true, excluded_inputs: [])
             self.model_name = model_name
             self.auto_load_attributes = attributes
             self.auto_load_associations = associations
@@ -51,11 +51,11 @@ module HQ
               excluded_inputs += ::HQ::GraphQL.excluded_inputs
 
               model_columns.each do |column|
-                argument_from_column(column) unless excluded_inputs.include?(column.name.to_sym)
+                argument_from_column(column, auto_nil: auto_nil) unless excluded_inputs.include?(column.name.to_sym)
               end
 
               model_associations.each do |association|
-                argument_from_association(association) unless excluded_inputs.include?(association.name.to_sym)
+                argument_from_association(association, auto_nil: auto_nil) unless excluded_inputs.include?(association.name.to_sym)
               end
 
               argument :X, String, required: false
@@ -68,7 +68,7 @@ module HQ
 
           private
 
-          def argument_from_association(association)
+          def argument_from_association(association, auto_nil:)
             is_enum = is_enum?(association)
             input_or_type = is_enum ? ::HQ::GraphQL::Types[association.klass] : ::HQ::GraphQL::Inputs[association.klass]
             name = association.name
@@ -77,8 +77,10 @@ module HQ
             case association.macro
             when :has_many
               argument name, [input_or_type], required: false
+            when :has_one
+              argument name, input_or_type, required: auto_nil.nil? ? has_presence_validation?(association) : auto_nil
             else
-              argument name, input_or_type, required: false
+              argument name, input_or_type, required: auto_nil.nil? ? association_required?(association) : auto_nil
             end
 
             return if is_enum
@@ -92,14 +94,25 @@ module HQ
             nil
           end
 
-          def argument_from_column(column)
+          def argument_from_column(column, auto_nil:)
             name = column.name
             return if argument_exists?(name)
-            argument name, ::HQ::GraphQL::Types.type_from_column(column), required: false
+            argument name, ::HQ::GraphQL::Types.type_from_column(column), required: auto_nil.nil? ? column.null : auto_nil
           end
 
           def argument_exists?(name)
             !!arguments[camelize(name)]
+          end
+
+          def association_required?(association)
+            !association.options[:optional] || has_presence_validation?(association)
+          end
+
+          def has_presence_validation?(association)
+            model_klass.validators.any? do |validation|
+              next unless validation.class == ActiveRecord::Validations::PresenceValidator && !(validation.options.include?(:if) || validation.options.include?(:unless))
+              validation.attributes.any? { |a| a.to_s == association.name.to_s }
+            end
           end
         end
       end

--- a/lib/hq/graphql/nil_inputs.rb
+++ b/lib/hq/graphql/nil_inputs.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module HQ
+  module GraphQL
+    module NilInputs
+      class Error < StandardError
+        MISSING_TYPE_MSG = "The GraphQL type for `%{klass}` is missing."
+      end
+
+      def self.[](key)
+        @nil_inputs ||= Hash.new do |hash, klass|
+          hash[klass] = klass_for(klass)
+        end
+        @nil_inputs[key]
+      end
+
+      # Only being used in testing
+      def self.reset!
+        @nil_inputs = nil
+      end
+
+      class << self
+        private
+
+        def klass_for(klass_or_string)
+          klass = klass_or_string.is_a?(String) ? klass_or_string.constantize : klass_or_string
+          resource = ::HQ::GraphQL.lookup_resource(klass)
+
+          raise(Error, Error::MISSING_TYPE_MSG % { klass: klass.name }) if !resource
+          resource.nil_input_klass
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -156,9 +156,6 @@ module HQ
 
         def input(**options, &block)
           @input_klass = build_input_object(**options, &block)
-        end
-
-        def nil_input(**options, &block)
           @nil_input_klass = build_input_object(**options, name: "#{options.try(:name) || graphql_name}Nil", &block)
         end
 

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -60,11 +60,11 @@ module HQ
         end
 
         def input_klass
-          @input_klass ||= const_set(:Input, build_input_object)
+            @input_klass ||= const_set(:Input, build_input_object)
         end
 
         def nil_input_klass
-          @nil_input_klass ||= const_set(:NilInput, build_input_object(name: "#{graphql_name}Nil", auto_nil: false))
+            @nil_input_klass ||= const_set(:NilInput, build_input_object(name: "#{graphql_name}Nil"))
         end
 
         def nil_query_object
@@ -156,7 +156,7 @@ module HQ
 
         def input(**options, &block)
           @input_klass = build_input_object(**options, &block)
-          @nil_input_klass = build_input_object(**options, name: "#{options.try(:name) || graphql_name}Nil", auto_nil: false, &block)
+          @nil_input_klass = build_input_object(**options, name: "#{options.try(:name) || graphql_name}Nil", &block)
         end
 
         # mutations generates available default mutations on RootMutation for a certain resource
@@ -234,7 +234,7 @@ module HQ
           else
             resolver = -> {
               klass = Class.new(::GraphQL::Schema::Resolver) do
-                type = new_query ? resource.nil_query_object : resource.query_object
+                type = resource.query_object
                 type type, null: null
                 class_eval(&block) if block
               end
@@ -308,6 +308,7 @@ module HQ
           scoped_graphql_name = name
           scoped_model_name = model_name
           object_class = @query_class || ::HQ::GraphQL.default_object_class || ::GraphQL::Schema::Object
+
           Class.new(object_class) do
             graphql_name scoped_graphql_name
 
@@ -319,7 +320,7 @@ module HQ
           end
         end
 
-        def build_input_object(name: graphql_name, **options, &block)
+          def build_input_object(name: graphql_name, **options, &block)
           scoped_graphql_name = name
           scoped_model_name = model_name
           scoped_excluded_inputs = @excluded_inputs || []

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -234,7 +234,7 @@ module HQ
           else
             resolver = -> {
               klass = Class.new(::GraphQL::Schema::Resolver) do
-                type = resource.query_object
+                type = new_query ? resource.nil_query_object : resource.query_object
                 type type, null: null
                 class_eval(&block) if block
               end

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -64,7 +64,7 @@ module HQ
         end
 
         def nil_input_klass
-          @nil_input_klass ||= const_set(:NilInput, build_input_object(name: "#{graphql_name}Nil"))
+          @nil_input_klass ||= const_set(:NilInput, build_input_object(name: "#{graphql_name}Nil", auto_nil: false))
         end
 
         def nil_query_object
@@ -156,7 +156,7 @@ module HQ
 
         def input(**options, &block)
           @input_klass = build_input_object(**options, &block)
-          @nil_input_klass = build_input_object(**options, name: "#{options.try(:name) || graphql_name}Nil", &block)
+          @nil_input_klass = build_input_object(**options, name: "#{options.try(:name) || graphql_name}Nil", auto_nil: false, &block)
         end
 
         # mutations generates available default mutations on RootMutation for a certain resource

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.3.5"
+    VERSION = "2.3.6"
   end
 end

--- a/spec/internal/app/models/advisor.rb
+++ b/spec/internal/app/models/advisor.rb
@@ -2,5 +2,7 @@ class Advisor < ActiveRecord::Base
   belongs_to :organization
 
   def hydrate
+    self.name ||= "test name"
+    self.organization_id ||= Organization.first.id
   end
 end

--- a/spec/lib/graphql/nil_inputs_spec.rb
+++ b/spec/lib/graphql/nil_inputs_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe ::HQ::GraphQL::NilInputs do
+
+  describe ".[]" do
+    let(:graphql_klass) do
+      Class.new do
+        include ::HQ::GraphQL::Resource
+
+        self.model_name = "Advisor"
+
+        nil_input(attributes: false, associations: false) do
+          argument :customField, String, "Header for the post", required: true
+        end
+      end
+    end
+
+    it "finds the type" do
+      nil_input_object = graphql_klass.nil_input_klass
+
+      aggregate_failures do
+        expect(nil_input_object.superclass).to eql(::GraphQL::Schema::InputObject)
+        expect(nil_input_object).to eql(described_class[Advisor])
+        expect(nil_input_object.arguments.keys).to contain_exactly("customField")
+        nil_input_object.lazy_load!
+        expect(nil_input_object.arguments.keys).to contain_exactly("customField", "X")
+      end
+    end
+
+    it "finds the type when lookup is a string" do
+      nil_input_object = graphql_klass.nil_input_klass
+      expect(nil_input_object).to eql(described_class["Advisor"])
+    end
+
+    it "raises an exception for unknown types" do
+      expect { described_class[Advisor] }.to raise_error(described_class::Error)
+    end
+  end
+
+end

--- a/spec/lib/graphql/nil_inputs_spec.rb
+++ b/spec/lib/graphql/nil_inputs_spec.rb
@@ -9,7 +9,7 @@ describe ::HQ::GraphQL::NilInputs do
 
         self.model_name = "Advisor"
 
-        nil_input(attributes: false, associations: false) do
+        input(attributes: false, associations: false) do
           argument :customField, String, "Header for the post", required: true
         end
       end

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -53,6 +53,10 @@ describe ::HQ::GraphQL::Resource do
       expect(::HQ::GraphQL::Inputs[Advisor]).to eql(advisor_resource.input_klass)
     end
 
+    it "builds the nil input klass" do
+      expect(::HQ::GraphQL::NilInputs[Advisor]).to eql(advisor_resource.nil_input_klass)
+    end
+
     it "creates query fields" do
       query_object = ::HQ::GraphQL::Types[Advisor]
       query_object.lazy_load!
@@ -89,6 +93,17 @@ describe ::HQ::GraphQL::Resource do
       expect(::HQ::GraphQL::Inputs[Advisor].graphql_name).to eql("AdvisorInput")
     end
 
+    it "creates nil input arguments" do
+      ::HQ::GraphQL::NilInputs[Advisor].lazy_load!
+      expected = ["id", "organizationId", "name", "nickname", "createdAt", "updatedAt", "X"]
+      expect(::HQ::GraphQL::NilInputs[Advisor].arguments.keys).to contain_exactly(*expected)
+    end
+
+    it "creates nil input graphql name" do
+      ::HQ::GraphQL::NilInputs[Advisor].lazy_load!
+      expect(::HQ::GraphQL::NilInputs[Advisor].graphql_name).to eql("AdvisorNilInput")
+    end
+
     it "doesn't create mutations" do
       expect(advisor_resource.mutation_klasses).to be_empty
     end
@@ -106,8 +121,10 @@ describe ::HQ::GraphQL::Resource do
 
       it "doesn't add organization type" do
         ::HQ::GraphQL::Inputs[Advisor].lazy_load!
+        ::HQ::GraphQL::NilInputs[Advisor].lazy_load!
         expected = ["id", "organizationId", "name", "nickname", "createdAt", "updatedAt", "X"]
         expect(::HQ::GraphQL::Inputs[Advisor].arguments.keys).to contain_exactly(*expected)
+        expect(::HQ::GraphQL::NilInputs[Advisor].arguments.keys).to contain_exactly(*expected)
       end
     end
   end
@@ -168,6 +185,10 @@ describe ::HQ::GraphQL::Resource do
           graphql_name "CustomAdvisorInput"
           remove_attr :name
         end
+        nil_input do
+          graphql_name "CustomAdvisorInput"
+          remove_attr :name
+        end
       end
     end
 
@@ -178,12 +199,16 @@ describe ::HQ::GraphQL::Resource do
 
     it "removes name" do
       ::HQ::GraphQL::Inputs[Advisor].lazy_load!
+      ::HQ::GraphQL::NilInputs[Advisor].lazy_load!
       expected = ["id", "nickname", "organizationId", "createdAt", "updatedAt", "X"]
       expect(::HQ::GraphQL::Inputs[Advisor].arguments.keys).to contain_exactly(*expected)
+      expect(::HQ::GraphQL::NilInputs[Advisor].arguments.keys).to contain_exactly(*expected)
     end
 
     it "customizes graphql name" do
       ::HQ::GraphQL::Inputs[Advisor].lazy_load!
+      ::HQ::GraphQL::NilInputs[Advisor].lazy_load!
+      expect(::HQ::GraphQL::Inputs[Advisor].graphql_name).to eql("CustomAdvisorInput")
       expect(::HQ::GraphQL::Inputs[Advisor].graphql_name).to eql("CustomAdvisorInput")
     end
   end
@@ -197,6 +222,10 @@ describe ::HQ::GraphQL::Resource do
         mutations
 
         input do
+          remove_attr :name
+          add_association :organization
+        end
+        nil_input do
           remove_attr :name
           add_association :organization
         end
@@ -292,8 +321,10 @@ describe ::HQ::GraphQL::Resource do
 
     it "removes id, createdAt and updatedAt" do
       ::HQ::GraphQL::Inputs[Advisor].lazy_load!
+      ::HQ::GraphQL::NilInputs[Advisor].lazy_load!
       expected = ["name", "nickname", "organizationId", "X"]
       expect(::HQ::GraphQL::Inputs[Advisor].arguments.keys).to contain_exactly(*expected)
+      expect(::HQ::GraphQL::NilInputs[Advisor].arguments.keys).to contain_exactly(*expected)
     end
   end
 

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -511,6 +511,7 @@ describe ::HQ::GraphQL::Resource do
     end
 
     it "uses new" do
+      organization = FactoryBot.create(:organization)
       results = schema.execute(new_advisor)
       data = results["data"]["newAdvisor"]
       expect(data.length).to be 2

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -185,10 +185,6 @@ describe ::HQ::GraphQL::Resource do
           graphql_name "CustomAdvisorInput"
           remove_attr :name
         end
-        nil_input do
-          graphql_name "CustomAdvisorInput"
-          remove_attr :name
-        end
       end
     end
 
@@ -222,10 +218,6 @@ describe ::HQ::GraphQL::Resource do
         mutations
 
         input do
-          remove_attr :name
-          add_association :organization
-        end
-        nil_input do
           remove_attr :name
           add_association :organization
         end


### PR DESCRIPTION
Description
-----------
Hydrate Queries receives an optional attribute parameter to set initial values before execute hydrate method. All parameters of this input, related to the query's resource, must be not required so the initial values can be fully optional and differ from mutations input that can contain required parameters

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
