### PR TITLE
[PD-10597][PD-12400] GraphQL Backend Restrictions

### DIFF
--- a/lib/hq/graphql/ext/object_extensions.rb
+++ b/lib/hq/graphql/ext/object_extensions.rb
@@ -98,7 +98,7 @@ module HQ
 
             field name, Types.type_from_column(column), null: !auto_nil || column.null,
             authorize: -> (obj, ctx) do
-              restriction = ctx[:restrictions]&.detect { |el|
+              restriction = ctx[:current_user]&.restrictions&.detect { |el|
                 (el.resource.name == name || el.resource.alias == name) &&
                 el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
                 el.resource.resource_type_id != "HasHelpers::ResourceType::::RequiredField"

--- a/lib/hq/graphql/ext/object_extensions.rb
+++ b/lib/hq/graphql/ext/object_extensions.rb
@@ -101,7 +101,7 @@ module HQ
               restriction = ctx[:current_user]&.restrictions&.detect do |el|
                 (el.resource.name == name || el.resource.alias == name) &&
                 el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
-                el.resource.resource_type_id != "HasHelpers::ResourceType::::RequiredField"
+                el.resource&.resource_type_id != "HasHelpers::ResourceType::::RequiredField"
               end
               return false if restriction.present?
               true

--- a/lib/hq/graphql/ext/object_extensions.rb
+++ b/lib/hq/graphql/ext/object_extensions.rb
@@ -98,10 +98,10 @@ module HQ
 
             field name, Types.type_from_column(column), null: !auto_nil || column.null,
             authorize: -> (obj, ctx) do
-              restriction = ctx[:restrictions].detect { |el|
+              restriction = ctx[:restrictions]&.detect { |el|
                 (el.resource.name == name || el.resource.alias == name) &&
-                el.restriction_operation == HasHelpers::RestrictionOperation::VIEW &&
-                el.resource.resource_type != HasHelpers::ResourceType::REQUIRED_FIELD
+                el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
+                el.resource.resource_type_id != "HasHelpers::ResourceType::::RequiredField"
               }
               return false if restriction.present?
               true

--- a/lib/hq/graphql/ext/object_extensions.rb
+++ b/lib/hq/graphql/ext/object_extensions.rb
@@ -96,7 +96,16 @@ module HQ
             name = column.name
             return if field_exists?(name)
 
-            field name, Types.type_from_column(column), null: !auto_nil || column.null
+            field name, Types.type_from_column(column), null: !auto_nil || column.null,
+            authorize: -> (obj, ctx) do
+              restriction = ctx[:restrictions].detect { |el|
+                (el.resource.name == name || el.resource.alias == name) &&
+                el.restriction_operation == HasHelpers::RestrictionOperation::VIEW &&
+                el.resource.resource_type != HasHelpers::ResourceType::REQUIRED_FIELD
+              }
+              return false if restriction.present?
+              true
+            end
           end
 
           def field_exists?(name)

--- a/lib/hq/graphql/ext/object_extensions.rb
+++ b/lib/hq/graphql/ext/object_extensions.rb
@@ -97,12 +97,12 @@ module HQ
             return if field_exists?(name)
 
             field name, Types.type_from_column(column), null: !auto_nil || column.null,
-            authorize: -> (obj, ctx) do
-              restriction = ctx[:current_user]&.restrictions&.detect { |el|
+            authorize: -> (_obj, ctx) do
+              restriction = ctx[:current_user]&.restrictions&.detect do |el|
                 (el.resource.name == name || el.resource.alias == name) &&
                 el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
                 el.resource.resource_type_id != "HasHelpers::ResourceType::::RequiredField"
-              }
+              end
               return false if restriction.present?
               true
             end

--- a/lib/hq/graphql/field_extension/association_loader_extension.rb
+++ b/lib/hq/graphql/field_extension/association_loader_extension.rb
@@ -7,13 +7,13 @@ module HQ
     module FieldExtension
       class AssociationLoaderExtension < ::GraphQL::Schema::FieldExtension
         def resolve(object:, **_kwargs)
-          restriction = _kwargs[:context][:current_user]&.restrictions&.detect { |el|
+          restriction = _kwargs[:context][:current_user]&.restrictions&.detect do |el|
             el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             (((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
             el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
             ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
             el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
-          }
+          end
           return {} if restriction.present?
           AssociationLoader.for(options[:klass], field.original_name).load(object.object)
         end

--- a/lib/hq/graphql/field_extension/association_loader_extension.rb
+++ b/lib/hq/graphql/field_extension/association_loader_extension.rb
@@ -10,11 +10,11 @@ module HQ
           restriction = _kwargs[:context][:current_user]&.restrictions&.detect do |el|
             el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             (((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
-            el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
-            ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
+            el.resource.resource_type_id == "HasHelpers::ResourceType::::Base") ||
+            ((el.resource&.parent&.name == options[:klass].name || el.resource&.parent&.alias == options[:klass].name) &&
             el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
           end
-          return {} if restriction.present?
+          # return {} if restriction.present?
           AssociationLoader.for(options[:klass], field.original_name).load(object.object)
         end
       end

--- a/lib/hq/graphql/field_extension/association_loader_extension.rb
+++ b/lib/hq/graphql/field_extension/association_loader_extension.rb
@@ -7,7 +7,7 @@ module HQ
     module FieldExtension
       class AssociationLoaderExtension < ::GraphQL::Schema::FieldExtension
         def resolve(object:, **_kwargs)
-          restriction = _kwargs[:context][:restrictions]&.detect { |el|
+          restriction = _kwargs[:context][:current_user]&.restrictions&.detect { |el|
             el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             (((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
             el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||

--- a/lib/hq/graphql/field_extension/association_loader_extension.rb
+++ b/lib/hq/graphql/field_extension/association_loader_extension.rb
@@ -7,6 +7,14 @@ module HQ
     module FieldExtension
       class AssociationLoaderExtension < ::GraphQL::Schema::FieldExtension
         def resolve(object:, **_kwargs)
+          restriction = _kwargs[:context][:restrictions].detect { |el|
+            el.restriction_operation == HasHelpers::RestrictionOperation::VIEW &&
+            (((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
+            el.resource_type == HasHelpers::ResourceType::BASE_RESOURCE) ||
+            ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
+            el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
+          }
+          return {} if restriction.present?
           AssociationLoader.for(options[:klass], field.original_name).load(object.object)
         end
       end

--- a/lib/hq/graphql/field_extension/association_loader_extension.rb
+++ b/lib/hq/graphql/field_extension/association_loader_extension.rb
@@ -7,10 +7,10 @@ module HQ
     module FieldExtension
       class AssociationLoaderExtension < ::GraphQL::Schema::FieldExtension
         def resolve(object:, **_kwargs)
-          restriction = _kwargs[:context][:restrictions].detect { |el|
-            el.restriction_operation == HasHelpers::RestrictionOperation::VIEW &&
+          restriction = _kwargs[:context][:restrictions]&.detect { |el|
+            el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             (((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
-            el.resource_type == HasHelpers::ResourceType::BASE_RESOURCE) ||
+            el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
             ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
             el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
           }

--- a/lib/hq/graphql/field_extension/paginated_loader.rb
+++ b/lib/hq/graphql/field_extension/paginated_loader.rb
@@ -24,10 +24,10 @@ module HQ
           )
 
           association_name = object.object.class.name.demodulize
-          restriction = _kwargs[:context][:restrictions].detect { |el|
-            (el.restriction_operation == HasHelpers::RestrictionOperation::VIEW &&
+          restriction = _options[:context][:restrictions]&.detect { |el|
+            (el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             ((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
-            el.resource_type == HasHelpers::ResourceType::BASE_RESOURCE) ||
+            el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
             ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
             el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
           }

--- a/lib/hq/graphql/field_extension/paginated_loader.rb
+++ b/lib/hq/graphql/field_extension/paginated_loader.rb
@@ -23,6 +23,16 @@ module HQ
             sort_order:           sort_order
           )
 
+          association_name = object.object.class.name.demodulize
+          restriction = _kwargs[:context][:restrictions].detect { |el|
+            (el.restriction_operation == HasHelpers::RestrictionOperation::VIEW &&
+            ((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
+            el.resource_type == HasHelpers::ResourceType::BASE_RESOURCE) ||
+            ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
+            el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
+          }
+          return {} if restriction.present?
+
           loader.load(object.object)
         end
 

--- a/lib/hq/graphql/field_extension/paginated_loader.rb
+++ b/lib/hq/graphql/field_extension/paginated_loader.rb
@@ -23,14 +23,13 @@ module HQ
             sort_order:           sort_order
           )
 
-          association_name = object.object.class.name.demodulize
-          restriction = _options[:context][:current_user]&.restrictions&.detect { |el|
+          restriction = _options[:context][:current_user]&.restrictions&.detect do |el|
             (el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             ((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
             el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
             ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
             el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
-          }
+          end
           return {} if restriction.present?
 
           loader.load(object.object)

--- a/lib/hq/graphql/field_extension/paginated_loader.rb
+++ b/lib/hq/graphql/field_extension/paginated_loader.rb
@@ -24,7 +24,7 @@ module HQ
           )
 
           association_name = object.object.class.name.demodulize
-          restriction = _options[:context][:restrictions]&.detect { |el|
+          restriction = _options[:context][:current_user]&.restrictions&.detect { |el|
             (el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             ((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
             el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||

--- a/lib/hq/graphql/field_extension/paginated_loader.rb
+++ b/lib/hq/graphql/field_extension/paginated_loader.rb
@@ -26,8 +26,8 @@ module HQ
           restriction = _options[:context][:current_user]&.restrictions&.detect do |el|
             (el.restriction_operation_id == "HasHelpers::RestrictionOperation::::View" &&
             ((el.resource.name == field.original_name.camelize || el.resource.alias == field.original_name.camelize) &&
-            el.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
-            ((el.resource.parent&.name == options[:klass].name || el.resource.parent&.alias == options[:klass].name) &&
+            el.resource.resource_type_id == "HasHelpers::ResourceType::::Base") ||
+            ((el.resource&.parent&.name == options[:klass].name || el.resource&.parent&.alias == options[:klass].name) &&
             el.resource.field_class_name == field.original_name.camelize || el.resource.alias == field.original_name.camelize))
           end
           return {} if restriction.present?

--- a/lib/hq/graphql/nil_inputs.rb
+++ b/lib/hq/graphql/nil_inputs.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module HQ
+  module GraphQL
+    module NilInputs
+      class Error < StandardError
+        MISSING_TYPE_MSG = "The GraphQL type for `%{klass}` is missing."
+      end
+
+      def self.[](key)
+        @nil_inputs ||= Hash.new do |hash, klass|
+          hash[klass] = klass_for(klass)
+        end
+        @nil_inputs[key]
+      end
+
+      # Only being used in testing
+      def self.reset!
+        @nil_inputs = nil
+      end
+
+      class << self
+        private
+
+        def klass_for(klass_or_string)
+          klass = klass_or_string.is_a?(String) ? klass_or_string.constantize : klass_or_string
+          resource = ::HQ::GraphQL.lookup_resource(klass)
+
+          raise(Error, Error::MISSING_TYPE_MSG % { klass: klass.name }) if !resource
+          resource.nil_input_klass
+        end
+      end
+    end
+  end
+end

--- a/lib/hq/graphql/resource/auto_mutation.rb
+++ b/lib/hq/graphql/resource/auto_mutation.rb
@@ -183,7 +183,7 @@ module HQ
             # return all restrictions related to a resource of type BaseResource, filtered by restriction operation type
             # restriction_operations is an array of ::HasHelpers::RestrictionOperation
             def get_base_restrictions(restriction_operations)
-              restrictions = context[:restrictions]&.select { |el|
+              restrictions = context[:current_user]&.restrictions&.select { |el|
                 (el.resource.resource_type_id == "HasHelpers::ResourceType::::BaseResource" &&
                 restriction_operations.include?(el.restriction_operation_id))
               }
@@ -206,7 +206,7 @@ module HQ
             # association_name is an specific resource used for filter restrictions
             # restriction_operations is an array of ::HasHelpers::RestrictionOperation
             def get_attributes_restrictions(association_name, restriction_operations)
-              restrictions = context[:restrictions]&.select { |el|
+              restrictions = context[:current_user]&.restrictions&.select { |el|
                 ((el.resource.parent&.name == association_name &&
                   el.resource.parent&.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
                 el.resource.resource_type_id == "HasHelpers::ResourceType::::BaseResource") &&
@@ -290,7 +290,7 @@ module HQ
               filtered_attrs = attributes.format_nested_attributes.with_indifferent_access
 
               filtered_attrs, restricted_attrs = recursive_nested_restrictions(association_name, filtered_attrs, {association_name.camelize(:lower) => []}, [restriction_operation], true).
-              values_at(:filtered_attrs, :restricted_attrs) if !context[:restrictions].blank?
+              values_at(:filtered_attrs, :restricted_attrs) if !context[:current_user]&.restrictions.blank?
 
               errors = {}
               errors = { "warning" => restricted_attrs} if !restricted_attrs.blank?

--- a/lib/hq/graphql/resource/auto_mutation.rb
+++ b/lib/hq/graphql/resource/auto_mutation.rb
@@ -183,10 +183,10 @@ module HQ
             # return all restrictions related to a resource of type BaseResource, filtered by restriction operation type
             # restriction_operations is an array of ::HasHelpers::RestrictionOperation
             def get_base_restrictions(restriction_operations)
-              restrictions = context[:current_user]&.restrictions&.select { |el|
+              restrictions = context[:current_user]&.restrictions&.select do |el|
                 (el.resource.resource_type_id == "HasHelpers::ResourceType::::BaseResource" &&
                 restriction_operations.include?(el.restriction_operation_id))
-              }
+              end
               restrictions
             end
 
@@ -195,50 +195,68 @@ module HQ
             # restriction_operation is a ::HasHelpers::RestrictionOperation type
             def is_base_restricted(association_name, restriction_operation)
               association_name = association_name.demodulize
-              restriction = get_base_restrictions([restriction_operation])&.detect { |el|
+              restriction = get_base_restrictions([restriction_operation])&.detect do |el|
                 el.resource.name == association_name
-              }
+              end
               restriction.present?
             end
 
-            # Return all attribute restriction related to a specific resource and also all BaseResource restrictions,
+            # Return all attribute restrictions related to a specific resource and also all BaseResource restrictions,
             # both filtered by restriction operation
             # association_name is an specific resource used for filter restrictions
             # restriction_operations is an array of ::HasHelpers::RestrictionOperation
             def get_attributes_restrictions(association_name, restriction_operations)
-              restrictions = context[:current_user]&.restrictions&.select { |el|
+              restrictions = context[:current_user]&.restrictions&.select do |el|
                 ((el.resource.parent&.name == association_name &&
                   el.resource.parent&.resource_type_id == "HasHelpers::ResourceType::::BaseResource") ||
                 el.resource.resource_type_id == "HasHelpers::ResourceType::::BaseResource") &&
                 restriction_operations.include?(el.restriction_operation_id)
-              }
+              end
 
               restrictions
             end
 
             def get_excluded_attrs(filtered_attrs, restrictions, restriction_operation, is_root)
-              restrictions.select { |r|
-                selected_restriction_operation = is_root ? restriction_operation.first : ((filtered_attrs.key?("id") ? "HasHelpers::RestrictionOperation::::Update" : "HasHelpers::RestrictionOperation::::Create"))
-                filtered_attrs.with_indifferent_access.keys.include?(r[0]) && r[1] == selected_restriction_operation
-              }.reject { |c| c.empty? }
+              restrictions.select do |r|
+                selected_restriction_operation = is_root ? restriction_operation.first : (
+                  filtered_attrs.key?("id") ? "HasHelpers::RestrictionOperation::::Update" : "HasHelpers::RestrictionOperation::::Create"
+                )
+                filtered_attrs.with_indifferent_access.key?(r[0]) && r[1] == selected_restriction_operation
+              end.reject { |c| c.empty? }
             end
 
+            # Return filtered nested attributes and a list of the restricted attributes,
+            # based on restrictions
+            # model_name is used to specify the model inside the restricted attributes
+            # attr is the object that can have nested attributes
+            # attr_restrictions are the restrictions related to the model_name
+            # filtered_attrs are the initial attributes
+            # restricted_attrs are the initial restricted attributes.
             def apply_restrictions_in_nested(model_name, attr, attr_restrictions, filtered_attrs, restricted_attrs)
               nested_attributes = attr.keys.select { |el| el.to_s.include?("_attributes") }
-              nested_attributes.each{ |el|
-                nested_attr_name = el.gsub("_attributes","").classify
-                filtered_attr_restrictions = attr_restrictions&.detect { |el| el.resource.name == nested_attr_name || el.resource.name.gsub("_id","").classify == nested_attr_name }
-                if(!filtered_attr_restrictions.blank?)
+              nested_attributes.each do |el|
+                nested_attr_name = el.gsub("_attributes", "").classify
+                # check if restrictions of create/edit and/or assign nested resource exist
+                # if restrictions exist, remove nested attribute from filtered_attrs
+                # else search restricted attributes from nested attribute recursively
+                filtered_attr_restrictions = attr_restrictions&.detect do |ar|
+                  ar.resource.name == nested_attr_name || ar.resource.name.gsub("_id", "").classify == nested_attr_name
+                end
+                if filtered_attr_restrictions.present?
                   restricted_attrs[model_name.camelize(:lower)].push(nested_attr_name.camelize(:lower) => "don't have permissions to create/edit")
                   filtered_attrs = filtered_attrs.except(el)
                 else
-                  result = recursive_nested_restrictions(nested_attr_name, filtered_attrs[el], {nested_attr_name.camelize(:lower) => []}, ["HasHelpers::RestrictionOperation::::Create", "HasHelpers::RestrictionOperation::::Update"])
+                  result = recursive_nested_restrictions(
+                    nested_attr_name, filtered_attrs[el],
+                    { nested_attr_name.camelize(:lower) => [] },
+                    ["HasHelpers::RestrictionOperation::::Create", "HasHelpers::RestrictionOperation::::Update"]
+                  )
                   filtered_attrs[el] = result[:filtered_attrs]
-                  filtered_attrs =  filtered_attrs.except(el) if filtered_attrs[el].blank?
-                  restricted_attrs[model_name.camelize(:lower)].push(result[:restricted_attrs]) if !result[:restricted_attrs].blank?
+                  filtered_attrs = filtered_attrs.except(el) if filtered_attrs[el].blank?
+                  restricted_attrs[model_name.camelize(:lower)].push(result[:restricted_attrs]) if result[:restricted_attrs].present?
                 end
-              }
-              return { filtered_attrs: filtered_attrs, restricted_attrs: restricted_attrs }
+              end
+              { filtered_attrs: filtered_attrs, restricted_attrs: restricted_attrs }
             end
 
             # Returns filtered mutation arguments based on restrictions and a list of filtered arguments
@@ -250,30 +268,33 @@ module HQ
               # gets attribute restrictions of a resource
               # if restrictions exist, add related args to restricted_attrs array and removes those args from filtered_attrs
               restrictions = get_attributes_restrictions(model_name, restriction_operation)
-              restrictions = restrictions.map{ |el| [el.resource.name, el.restriction_operation_id] } if !restrictions.empty?
-              if(!restrictions.blank?)
+              restrictions = restrictions.map { |el| [el.resource.name, el.restriction_operation_id] } if !restrictions.empty?
+              if restrictions.present?
                 excluded_attrs = filtered_attrs.kind_of?(Array) ?
-                filtered_attrs.map{ |attr| get_excluded_attrs(attr, restrictions, restriction_operation, is_root) }.reject { |c| c.empty? } :
+                filtered_attrs.map { |attr| get_excluded_attrs(attr, restrictions, restriction_operation, is_root) }.reject { |c| c.empty? } :
                 get_excluded_attrs(filtered_attrs, restrictions, restriction_operation, is_root)
 
-                restricted_attrs[model_name.camelize(:lower)] += excluded_attrs.map { |el| {el[0].camelize(:lower) => "don't have permissions to #{el[1].demodulize.camelize(:lower)}"}} if !excluded_attrs.blank?
+                restricted_attrs[model_name.camelize(:lower)] += excluded_attrs.map do |el|
+                  { el[0].camelize(:lower) => "don't have permissions to #{el[1].demodulize.camelize(:lower)}" }
+                end if excluded_attrs.present?
 
                 filtered_attrs = filtered_attrs.kind_of?(Array) ?
-                filtered_attrs.map{ |el| el.with_indifferent_access.except(*restrictions.flatten) } :
-                filtered_attrs.with_indifferent_access.except(*restrictions.flatten) if !restrictions.blank?
+                filtered_attrs.map { |el| el.with_indifferent_access.except(*restrictions.flatten) } :
+                filtered_attrs.with_indifferent_access.except(*restrictions.flatten) if restrictions.present?
               end
 
               # if there's an association for create/update, checks the existance of related restrictions
               # if restrictions exist, add related args to restricted_attrs array and removes those args from filtered_attrs
-              attr_restrictions = (get_base_restrictions(
-                ["HasHelpers::RestrictionOperation::::Create", "HasHelpers::RestrictionOperation::::Update"]) +
-                get_attributes_restrictions(model_name, ["HasHelpers::RestrictionOperation::::Create", "HasHelpers::RestrictionOperation::::Update"]))
-              if(filtered_attrs.kind_of?(Array))
-                filtered_attrs.each_with_index{ |attr, idx|
+              attr_restrictions = (
+                get_base_restrictions(["HasHelpers::RestrictionOperation::::Create", "HasHelpers::RestrictionOperation::::Update"]) +
+                get_attributes_restrictions(model_name, ["HasHelpers::RestrictionOperation::::Create", "HasHelpers::RestrictionOperation::::Update"])
+              )
+              if filtered_attrs.kind_of?(Array)
+                filtered_attrs.each_with_index do |attr, idx|
                   result = apply_restrictions_in_nested(model_name, attr, attr_restrictions, filtered_attrs[idx], restricted_attrs)
                   filtered_attrs[idx] = result[:filtered_attrs]
                   restricted_attrs = result[:restricted_attrs]
-                }
+                end
                 filtered_attrs = filtered_attrs.reject { |c| c.blank? }
               else
                 filtered_attrs, restricted_attrs = apply_restrictions_in_nested(model_name, filtered_attrs, attr_restrictions, filtered_attrs, restricted_attrs).
@@ -281,7 +302,7 @@ module HQ
               end
               restricted_attrs[model_name.camelize(:lower)] = restricted_attrs[model_name.camelize(:lower)].uniq
               restricted_attrs = restricted_attrs.except(model_name.camelize(:lower)) if restricted_attrs.kind_of?(Hash) && restricted_attrs[model_name.camelize(:lower)].blank?
-              return { filtered_attrs: filtered_attrs, restricted_attrs: restricted_attrs }
+              { filtered_attrs: filtered_attrs, restricted_attrs: restricted_attrs }
             end
 
             # returns mutation args filtered by restrictions and errors warning with all args removed
@@ -289,11 +310,15 @@ module HQ
               association_name = model_name.demodulize
               filtered_attrs = attributes.format_nested_attributes.with_indifferent_access
 
-              filtered_attrs, restricted_attrs = recursive_nested_restrictions(association_name, filtered_attrs, {association_name.camelize(:lower) => []}, [restriction_operation], true).
-              values_at(:filtered_attrs, :restricted_attrs) if !context[:current_user]&.restrictions.blank?
+              filtered_attrs, restricted_attrs = recursive_nested_restrictions(
+                association_name,
+                filtered_attrs,
+                { association_name.camelize(:lower) => [] },
+                [restriction_operation], true
+              ).values_at(:filtered_attrs, :restricted_attrs) if context[:current_user]&.restrictions.present?
 
               errors = {}
-              errors = { "warning" => restricted_attrs} if !restricted_attrs.blank?
+              errors = { "warning" => restricted_attrs } if restricted_attrs.present?
 
               { errors: errors, filtered_attrs: filtered_attrs }
             end

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.3.5"
+    VERSION = "2.3.6"
   end
 end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :resource do
     name                   { Faker::Commerce.product_name }
     add_attribute(:alias)  { @alias ? @alias : @name }
-    resource_type_id       { "::HasHelpers::ResourceType::#{["BaseResource", "Field"].sample}" }
-    parent                 { FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::BaseResource") }
-    field_resource         { [FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::BaseResource"), nil].sample }
+    resource_type_id       { "::HasHelpers::ResourceType::#{["Base", "Field"].sample}" }
+    parent                 { FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::Base") }
+    field_resource         { [FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::Base"), nil].sample }
     field_class_name       { @field_resource.nil? ? nil : @field_resource&.name }
   end
 end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :resource do
+    name                   { Faker::Commerce.product_name }
+    resource_type_id       { "::HasHelpers::ResourceType::#{["BaseResource", "Field"].sample}" }
+    parent                 { FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::BaseResource") }
+    field_resource         { [FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::BaseResource"), nil].sample }
+    field_class_name       { @field_resource.nil? ? nil : @field_resource&.name }
+  end
+end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :resource do
     name                   { Faker::Commerce.product_name }
+    add_attribute(:alias)  { @alias ? @alias : @name }
     resource_type_id       { "::HasHelpers::ResourceType::#{["BaseResource", "Field"].sample}" }
     parent                 { FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::BaseResource") }
     field_resource         { [FactoryBot.create(:resource, resource_type_id: "::HasHelpers::ResourceType::::BaseResource"), nil].sample }

--- a/spec/factories/restrictions.rb
+++ b/spec/factories/restrictions.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :restriction do
+    resource                  { FactoryBot.create(:resource) }
+    role                      { FactoryBot.create(:role) }
+    restriction_operation_id  { "::HasHelpers::RestrictionOperation::#{["Create","Update", "Destroy", "Copy"].sample}" }
+    organization              { FactoryBot.create(:organization) }
+  end
+end

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :role do
+    name                   { Faker::Commerce.product_name }
+    organization           { FactoryBot.create(:organization) }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :user do
     name                { Faker::Name.name }
     organization        { FactoryBot.build(:organization) }
+    role                { FactoryBot.build(:role) }
   end
 end

--- a/spec/internal/app/models/advisor.rb
+++ b/spec/internal/app/models/advisor.rb
@@ -1,5 +1,6 @@
 class Advisor < ActiveRecord::Base
   belongs_to :organization
+  belongs_to :optional_org, class_name: "::Organization", optional: true
 
   def hydrate
   end

--- a/spec/internal/app/models/resource.rb
+++ b/spec/internal/app/models/resource.rb
@@ -1,0 +1,8 @@
+class Resource < ::ActiveRecord::Base
+  belongs_to :parent, class_name: "::Resource", optional: true
+  belongs_to :field_resource, class_name: "::Resource", optional: true
+
+  has_many :resources, foreign_key: "parent_id", dependent: :destroy, inverse_of: :parent
+  has_many :resources, foreign_key: "field_resource_id", dependent: :destroy, inverse_of: :field_resource
+  has_many :restrictions
+end

--- a/spec/internal/app/models/restriction.rb
+++ b/spec/internal/app/models/restriction.rb
@@ -1,0 +1,5 @@
+class Restriction < ::ActiveRecord::Base
+  belongs_to :organization
+  belongs_to :resource
+  belongs_to :role
+end

--- a/spec/internal/app/models/role.rb
+++ b/spec/internal/app/models/role.rb
@@ -1,0 +1,5 @@
+class Role < ::ActiveRecord::Base
+  belongs_to :organization
+
+  has_many :restrictions
+end

--- a/spec/internal/app/models/role.rb
+++ b/spec/internal/app/models/role.rb
@@ -2,4 +2,5 @@ class Role < ::ActiveRecord::Base
   belongs_to :organization
 
   has_many :restrictions
+  has_many :users
 end

--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ::ActiveRecord::Base
   belongs_to :advisor, optional: true
   belongs_to :manager, optional: true
   belongs_to :organization
+  belongs_to :role
+
+  has_many :restrictions, through: :role
 
   def hydrate
   end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -11,10 +11,12 @@ ActiveRecord::Schema.define do
 
   create_table "advisors", force: true, id: :uuid do |t|
     t.references  :organization,       null: false, index: true, foreign_key: true, type: :uuid
+    t.uuid        :optional_org_id
     t.string      :name,               null: false
-    t.string      :nickname,           null: false
+    t.string      :nickname
     t.timestamps                       null: false
   end
+  add_foreign_key :advisors, :organizations, column: :optional_org_id
 
   create_table "managers", force: true, id: :uuid do |t|
     t.references  :organization,       null: false, index: true, foreign_key: true, type: :uuid
@@ -28,6 +30,7 @@ ActiveRecord::Schema.define do
 
   create_table "resources", force: true, id: :uuid do |t|
     t.string      :name,               null: false
+    t.string      :alias,              null: false
     t.string      :resource_type_id,   null: false
     t.uuid        :parent_id
     t.uuid        :field_resource_id

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define do
 
   create_table "resources", force: true, id: :uuid do |t|
     t.string      :name,               null: false
-    t.string      :alias,              null: false
+    t.string      :alias
     t.string      :resource_type_id,   null: false
     t.uuid        :parent_id
     t.uuid        :field_resource_id
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define do
 
   create_table "users", force: true, id: :uuid do |t|
     t.belongs_to  :organization,       null: false, index: true, foreign_key: true, type: :uuid
+    t.belongs_to  :role,               null: false, index: true, foreign_key: true, type: :uuid
     t.belongs_to  :advisor,            null: true, index: true, foreign_key: true, type: :uuid
     t.belongs_to  :manager,            null: true, index: true, foreign_key: true, type: :uuid
     t.boolean     :inactive

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -21,6 +21,28 @@ ActiveRecord::Schema.define do
     t.timestamps                       null: false
   end
 
+  create_table "roles", force: true, id: :uuid do |t|
+    t.references  :organization,       null: false, index: true, foreign_key: true, type: :uuid
+    t.string      :name,               null: false
+  end
+
+  create_table "resources", force: true, id: :uuid do |t|
+    t.string      :name,               null: false
+    t.string      :resource_type_id,   null: false
+    t.uuid        :parent_id
+    t.uuid        :field_resource_id
+    t.string      :field_class_name
+  end
+  add_foreign_key :resources, :resources, column: :parent_id
+  add_foreign_key :resources, :resources, column: :field_resource_id
+
+  create_table "restrictions", force: true, id: :uuid do |t|
+    t.references  :organization,              null: false, index: true, foreign_key: true, type: :uuid
+    t.references  :role,                      null: false, index: true, foreign_key: true, type: :uuid
+    t.references  :resource,                  null: false, index: true, foreign_key: true, type: :uuid
+    t.string      :restriction_operation_id,  null: false
+  end
+
   create_table "users", force: true, id: :uuid do |t|
     t.belongs_to  :organization,       null: false, index: true, foreign_key: true, type: :uuid
     t.belongs_to  :advisor,            null: true, index: true, foreign_key: true, type: :uuid

--- a/spec/lib/graphql/ext/input_object_extensions_spec.rb
+++ b/spec/lib/graphql/ext/input_object_extensions_spec.rb
@@ -28,7 +28,7 @@ describe ::HQ::GraphQL::Ext::InputObjectExtensions do
 
       expect(hq_input_object.arguments.keys).to be_empty
       hq_input_object.lazy_load!
-      expected = ["createdAt", "id", "name", "nickname", "organizationId", "updatedAt", "X"]
+      expected = ["createdAt", "id", "name", "nickname", "optionalOrgId", "organizationId", "updatedAt", "X"]
       expect(hq_input_object.arguments.keys).to contain_exactly(*expected)
     end
 
@@ -49,7 +49,7 @@ describe ::HQ::GraphQL::Ext::InputObjectExtensions do
     describe ".remove_attributes" do
       it "removes an attribute" do
         hq_input_object.class_eval do
-          remove_attributes :created_at, :id, :organization_id
+          remove_attributes :created_at, :id, :organization_id, :optional_org_id
           with_model "Advisor"
         end
 
@@ -86,7 +86,7 @@ describe ::HQ::GraphQL::Ext::InputObjectExtensions do
 
         expect(hq_input_object.arguments.keys).to be_empty
         hq_input_object.lazy_load!
-        expected = ["createdAt", "id", "name", "nickname", "organizationId", "updatedAt", "X"]
+        expected = ["createdAt", "id", "name", "nickname", "optionalOrgId", "organizationId", "updatedAt", "X"]
         expect(hq_input_object.arguments.keys).to contain_exactly(*expected)
       end
 

--- a/spec/lib/graphql/ext/object_extensions_spec.rb
+++ b/spec/lib/graphql/ext/object_extensions_spec.rb
@@ -28,7 +28,7 @@ describe ::HQ::GraphQL::Ext::ObjectExtensions do
 
       expect(hq_object.fields.keys).to be_empty
       hq_object.lazy_load!
-      expected = ["createdAt", "id", "name", "nickname", "organization", "organizationId", "updatedAt"]
+      expected = ["createdAt", "id", "name", "nickname", "optionalOrg", "optionalOrgId", "organization", "organizationId", "updatedAt"]
       expect(hq_object.fields.keys).to contain_exactly(*expected)
     end
 
@@ -49,13 +49,13 @@ describe ::HQ::GraphQL::Ext::ObjectExtensions do
     describe ".remove_attributes" do
       it "removes an attribute" do
         hq_object.class_eval do
-          remove_attributes :created_at, :id, :organization_id
+          remove_attributes :created_at, :id, :organization_id, :optional_org_id
           with_model "Advisor"
         end
 
         expect(hq_object.fields.keys).to be_empty
         hq_object.lazy_load!
-        expected = ["name", "nickname", "organization", "updatedAt"]
+        expected = ["name", "nickname", "optionalOrg", "organization", "updatedAt"]
         expect(hq_object.fields.keys).to contain_exactly(*expected)
       end
 
@@ -81,12 +81,13 @@ describe ::HQ::GraphQL::Ext::ObjectExtensions do
       it "removes an association" do
         hq_object.class_eval do
           remove_associations :organization
+          remove_associations :optional_org
           with_model "Advisor"
         end
 
         expect(hq_object.fields.keys).to be_empty
         hq_object.lazy_load!
-        expected = ["createdAt", "id", "name", "nickname", "organizationId", "updatedAt"]
+        expected = ["createdAt", "id", "name", "nickname", "optionalOrgId", "organizationId", "updatedAt"]
         expect(hq_object.fields.keys).to contain_exactly(*expected)
       end
 


### PR DESCRIPTION
Description
-----------
Implements access of the following list:

1. Queries
2. Query Fields
3. Mutations
4. Mutation Arguments

based on role's restrictions. If restrictions doesn't exist, it will display full data.

Result Format
-----------
Queries:
if a certain attribute has a view restriction, it will return null. Required fields can't be restricted because this will cause a schema conflict.

Mutations:
following graphql's result structure, warnings will be added inside { errors: warning: ... } and it will contain a list of the attributes/arguments (key) with the restriction (value). In the following example, it displays `Project` restrictions on `name` attribute and also restrictions on `User's teamId` attribute, which is a `Project Texter's` nested resource:

```
"errors": {
        "warning": {
          "project": [
            {
              "name": "don't have permissions to update"
            },
            {
              "projectTexter": [
                {
                  "user": [
                    {
                      "teamId": "don't have permissions to create"
                    }
                  ]
                }
              ]
            }
          ]
        }
      }
```

obs:
- Required fields can't be restricted for queries and mutations because of schema conflicts.
- Specify restriction type warning for nested attributes will be added in another ticket

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
