### PR TITLE
[PD-15534] force max limit in all list queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,88 @@
 
 ### Bug fixes
 
+# 2.3.6 (6 December 2024)
+
+### Bug fixes
+
+- All pagination queries created with root_query, def_root and resolvers will have a 250 limit as default. 
+
+# 2.3.5 (14 January 2023)
+
+### Breaking changes
+
+- New Queries will execute validations instead of after_initialize callback. Will accept initial parameters before run validations
+
+# 2.3.4 (6 March 2023)
+
+### Breaking changes
+
+- limit_max is removed from root_query. Now is 250
+
+# 2.3.3 (3 February 2023)
+
+### New features
+
+- By default, New Queries will be generated if Create Mutation is available. These queries will be useful for forms init. Default values will be based on methods applied using after_initialize callback on model.
+
+```
+{
+  newAdvisor {
+    name
+    advisor_status_id
+    demographic {
+      id
+      ...
+    }
+  }
+}
+```
+
+# 2.3.2 (13 January 2023)
+
+### New features
+
+- Root queries filters with new filters:
+  Operation IN: field included in array_values
+  OR filter: add isOr: true to pass an OR statement (based on filter order passed)
+  Comparison between columns: using column_value argument
+
+# 2.3.0 (8 November 2022)
+
+### Breaking changes
+
+- All list queries are now pagination based on queries (connection type)
+
+# 2.2.6 (23 September 2022)
+
+### New features
+
+- List queries with optional pagination based on queries (connection type)
+```
+query {
+  userPagination(filters:[UserQueryFilterInput]! , limit: Int, sortOrder: SortOrder, sortBy: SortBy, first: Int, after: String){
+       totalCount
+       cursors
+       pageInfo{ startCursor  endCursor }
+      edges { cursor node{ id name } }
+  }
+}
+```
+
+
+
+# 2.2.6 (14 February 2022)
+
+### Bug fixes
+
+- FilterInput type naming change due to naming collision with resources
+
+# 2.2.5 (2 November 2021)
+
+### Bug fixes
+
+- Date Type issue fixed
+
 # 2.2.4 (8 October 2021)
 
 ### Bug fixes

--- a/lib/hq/graphql/ext/schema_extensions.rb
+++ b/lib/hq/graphql/ext/schema_extensions.rb
@@ -4,47 +4,58 @@ module HQ
   module GraphQL
     module Ext
       module SchemaExtensions
-        def self.prepended(klass)
-          klass.alias_method :add_type_and_traverse_without_types, :add_type_and_traverse
-          klass.alias_method :add_type_and_traverse, :add_type_and_traverse_with_types
-        end
+        MAX_RESULTS = 250
 
-        def multiplex(*args, **options)
-          load_types!
-          super
-        end
+        module Prepend
+          def self.prepended(klass)
+            klass.alias_method :add_type_and_traverse_without_types, :add_type_and_traverse
+            klass.alias_method :add_type_and_traverse, :add_type_and_traverse_with_types
+          end
+          def multiplex(*args, **options)
+            load_types!
+            super
+          end
 
-        def dump_directory(directory = Rails.root.join("app/graphql"))
-          @dump_directory ||= directory
-        end
+          def dump_directory(directory = Rails.root.join("app/graphql"))
+            @dump_directory ||= directory
+          end
 
-        def dump_filename(filename = "#{self.name.underscore}.graphql")
-          @dump_filename ||= filename
-        end
+          def dump_filename(filename = "#{self.name.underscore}.graphql")
+            @dump_filename ||= filename
+          end
 
-        def dump
-          load_types!
-          ::FileUtils.mkdir_p(dump_directory)
-          ::File.open(::File.join(dump_directory, dump_filename), "w") { |file| file.write(self.to_definition) }
-        end
+          def dump
+            load_types!
+            ::FileUtils.mkdir_p(dump_directory)
+            ::File.open(::File.join(dump_directory, dump_filename), "w") { |file| file.write(self.to_definition) }
+          end
 
-        def load_types!
-          ::HQ::GraphQL.load_types!
-          return if @add_type_and_traverse_with_types.blank?
-          while (args, options = @add_type_and_traverse_with_types.shift)
-            add_type_and_traverse_without_types(*args, **options)
+          def load_types!
+            ::HQ::GraphQL.load_types!
+            return if @add_type_and_traverse_with_types.blank?
+            while (args, options = @add_type_and_traverse_with_types.shift)
+              add_type_and_traverse_without_types(*args, **options)
+            end
+          end
+
+          # Defer adding types until first schema execution
+          # https://github.com/rmosolgo/graphql-ruby/blob/345ebb2e3833909963067d81e0e8378717b5bdbf/lib/graphql/schema.rb#L1792
+          def add_type_and_traverse_with_types(*args, **options)
+            @add_type_and_traverse_with_types ||= []
+            @add_type_and_traverse_with_types.push([args, options])
           end
         end
-
-        # Defer adding types until first schema execution
-        # https://github.com/rmosolgo/graphql-ruby/blob/345ebb2e3833909963067d81e0e8378717b5bdbf/lib/graphql/schema.rb#L1792
-        def add_type_and_traverse_with_types(*args, **options)
-          @add_type_and_traverse_with_types ||= []
-          @add_type_and_traverse_with_types.push([args, options])
+        module Include
+          # Force pagination queries limit
+          def self.included(klass)
+            super
+            klass.default_max_page_size MAX_RESULTS
+          end
         end
       end
     end
   end
 end
 
-::GraphQL::Schema.singleton_class.prepend ::HQ::GraphQL::Ext::SchemaExtensions
+::GraphQL::Schema.singleton_class.prepend ::HQ::GraphQL::Ext::SchemaExtensions::Prepend
+::GraphQL::Schema.include ::HQ::GraphQL::Ext::SchemaExtensions::Include

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.3.5"
+    VERSION = "2.3.6"
   end
 end

--- a/spec/lib/graphql/pagination_connection_type_spec.rb
+++ b/spec/lib/graphql/pagination_connection_type_spec.rb
@@ -123,4 +123,28 @@ describe ::HQ::GraphQL::PaginationConnectionType do
       expect(advisors).to eq test_types.first(1).map(&:id)
     end
   end
+
+  context "first + last" do
+    it "page size == 250 with first > 250" do
+      results = schema.execute(query, variables: { first: 1000, sortOrder: "ASC" })
+      data = results["data"]["testTypes"]["nodes"]
+      totalCount = results["data"]["testTypes"]["totalCount"]
+      expect(data.length).to be 250
+      expect(totalCount).to be 252
+    end
+    it "page size == 250 with last > 250" do
+      results = schema.execute(query, variables: { last: 1000, sortOrder: "ASC" })
+      data = results["data"]["testTypes"]["nodes"]
+      totalCount = results["data"]["testTypes"]["totalCount"]
+      expect(data.length).to be 250
+      expect(totalCount).to be 252
+    end
+    it "page size == 250 without first and last" do
+      results = schema.execute(query, variables: { first: 1000, sortOrder: "ASC" })
+      data = results["data"]["testTypes"]["nodes"]
+      totalCount = results["data"]["testTypes"]["totalCount"]
+      expect(data.length).to be 250
+      expect(totalCount).to be 252
+    end
+  end
 end

--- a/spec/lib/graphql/resource_spec.rb
+++ b/spec/lib/graphql/resource_spec.rb
@@ -335,8 +335,8 @@ describe ::HQ::GraphQL::Resource do
     }
 
     let(:find_advisors) { <<-GRAPHQL
-        query findAdvisors($limit: Int) {
-          advisors(limit: $limit) {
+        query findAdvisors($first: Int, $limit: Int) {
+          advisors(first: $first, limit: $limit) {
             nodes {
               name
               organizationId
@@ -426,7 +426,7 @@ describe ::HQ::GraphQL::Resource do
 
     it "uses pagination" do
       10.times { FactoryBot.create(:advisor) }
-      results = schema.execute(find_advisors, variables: { limit: 5 })
+      results = schema.execute(find_advisors, variables: { first: 5 })
       data = results["data"]["advisors"]["nodes"]
       expect(data.length).to be 5
     end


### PR DESCRIPTION
Description
-----------
Now all list queries created with root_query, def_root and custom resolvers will have a default 250 limit per page

Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have added appropriate tests if this PR fixes a bug or adds a feature.
- [ ] All [status checks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks) (tests, linting, etc...) are passing.
