### PR TITLE
[PD-26048] Make enums ordering stable

### DIFF
--- a/lib/hq/graphql/ext/enum_extensions.rb
+++ b/lib/hq/graphql/ext/enum_extensions.rb
@@ -50,6 +50,7 @@ module HQ::GraphQL
 
         lazy_load do
           records = scope ? klass.instance_exec(&scope) : klass.all
+          records = records.reorder(:id) if records.order_values.empty?
           records.each do |record|
             value "#{prefix}#{record.send(value_method).gsub(strip, "")}", value: record
           end

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "2.4.1"
+    VERSION = "2.4.2"
   end
 end

--- a/spec/lib/graphql/ext/enum_extensions_spec.rb
+++ b/spec/lib/graphql/ext/enum_extensions_spec.rb
@@ -39,6 +39,25 @@ describe ::HQ::GraphQL::Ext::EnumExtensions do
     expect { ::HQ::GraphQL::Types[Advisor] }.to raise_error ::HQ::GraphQL::Types::Error
   end
 
+  it "orders values by id when no scope-provided ordering is set" do
+    records = Array.new(3) { FactoryBot.create(:advisor, :simple_name) }
+    records[1].touch
+
+    enum = build_enum
+    enum.lazy_load!
+
+    expect(enum.values.values.map(&:value)).to eq records.sort_by(&:id)
+  end
+
+  it "respects caller-provided ordering from scope" do
+    records = Array.new(3) { FactoryBot.create(:advisor, :simple_name) }
+
+    enum = build_enum(scope: -> { order(id: :desc) })
+    enum.lazy_load!
+
+    expect(enum.values.values.map(&:value)).to eq records.sort_by(&:id).reverse
+  end
+
   it "supports scoping" do
     expected_keys = [advisor1.name.delete(" ")]
 


### PR DESCRIPTION
Description
-----------
Enums were being generated as `SomeKlass.all` this is converted to a `select * from some_table` which order cannot be garanteed by postgres and may vary from machine to machine or even across different runs. The result was that the enum types were being generated in random orders causing unnecessary schema drifts. This also conflicted with tools like codegen in other repos. Example:

<img width="1314" height="722" alt="CleanShot 2026-06-11 at 11 45 44@2x" src="https://github.com/user-attachments/assets/36a7e7a1-e6db-4429-bcf5-2536322c3da4" />

And since the constants id usually are based on their names, this also make sure they are generated in alphabetical order according to their names in most of the cases (most because there are cases where the id doesn't necessarily match the name).

<img width="3370" height="760" alt="CleanShot 2026-06-11 at 11 49 28@2x" src="https://github.com/user-attachments/assets/8faa664b-f239-4e2c-98d3-d3166cce8d67" />


Risk Level
-----------
- [X] Low
- [ ] Med
- [ ] High

Rollback Plan
-----------
Revert PR

Screenshots
-----------
Screenshots or videos of the feature/fix if needed.

<!-- SOC2_CHECKLIST_START -->
Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I linked the change to an approved ticket
- [X] I have added/updated appropriate tests and evidence
- [X] I considered security/privacy impact
- [X] I updated docs/runbook if needed
- [X] I added a changelog/version entry for this PR
<!-- SOC2_CHECKLIST_END -->
