### PR TITLE
[PD-30163] Search options improvements

### DIFF
--- a/.tekton/Chart.yaml
+++ b/.tekton/Chart.yaml
@@ -24,7 +24,7 @@ version: 0.1.0
 dependencies:
   - name: ruby-pipelines
     alias: delivery
-    version: "0.2.0-dev.4"
+    version: "0.2.0-dev.7"
     repository: "oci://public.ecr.aws/c6o8b8d1"
 # - name: gem-delivery
 #   alias: delivery

--- a/.tekton/Chart.yaml
+++ b/.tekton/Chart.yaml
@@ -24,7 +24,7 @@ version: 0.1.0
 dependencies:
   - name: ruby-pipelines
     alias: delivery
-    version: "0.2.0-dev.6"
+    version: "0.2.0-dev.4"
     repository: "oci://public.ecr.aws/c6o8b8d1"
 # - name: gem-delivery
 #   alias: delivery

--- a/.tekton/values.yaml
+++ b/.tekton/values.yaml
@@ -1,4 +1,4 @@
-rubyVersion: 3.4.4
+rubyVersion: 3.1.7
 publish: false
 
 gem: &gem hq-graphql
@@ -16,6 +16,6 @@ global:
     vault.security.banzaicloud.io/vault-path: "jwt-hub"
     vault.security.banzaicloud.io/vault-auth-method: "jwt"
     vault.security.banzaicloud.io/vault-tls-secret: "custom-trusted-ca"
-  rubyVersion: 3.4.4
+  rubyVersion: 3.1.7
   gem: *gem
   mountGemDockerfile: true

--- a/.tekton/values.yaml
+++ b/.tekton/values.yaml
@@ -1,4 +1,4 @@
-rubyVersion: 3.1.7
+rubyVersion: 3.4.4
 publish: false
 
 gem: &gem hq-graphql
@@ -16,6 +16,6 @@ global:
     vault.security.banzaicloud.io/vault-path: "jwt-hub"
     vault.security.banzaicloud.io/vault-auth-method: "jwt"
     vault.security.banzaicloud.io/vault-tls-secret: "custom-trusted-ca"
-  rubyVersion: 3.1.7
+  rubyVersion: 3.4.4
   gem: *gem
   mountGemDockerfile: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixed** for any bug fixes.
 - **Security** in case of vulnerabilities.
 
+# [5.0.5] 2026-09-04
+
+### Changed
+
+- The `search_options` resolver no longer applies a default limit of 15 when the caller doesn't pass `with: { limit: }`. `default_limit:` now defaults to `nil`, so results are unbounded unless the caller passes `limit`, or the resource explicitly opts into a cap via `search_options(default_limit: N)`.
+
+# [5.0.4] 2026-09-03
+
+### Changed
+
+- The `search_options` resolver (from `auto_register_search_options!`) now passes `current_user: context[:current_user]` and `current_application: context[:current_application]` through to the model's `.search_options(query, options)` call, alongside the existing `organization_id`/`with`. Additive — existing `.search_options` implementations that don't read those keys are unaffected. Lets a model's `search_options` call into `HasHelpers::Search.search` (which needs a real user/application), instead of being limited to plain ActiveRecord queries.
+
 # [2.2.0] 2021-01-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `search_options` resolver (from `auto_register_search_options!`) now passes `current_user: context[:current_user]` and `current_application: context[:current_application]` through to the model's `.search_options(query, options)` call, alongside the existing `organization_id`/`with`. Additive — existing `.search_options` implementations that don't read those keys are unaffected. Lets a model's `search_options` call into `HasHelpers::Search.search` (which needs a real user/application), instead of being limited to plain ActiveRecord queries.
 - The `search_options` resolver no longer applies a default limit of 15 when the caller doesn't pass `with: { limit: }`. `default_limit:` now defaults to `nil`, so results are unbounded unless the caller passes `limit`, or the resource explicitly opts into a cap via `search_options(default_limit: N)`.
 
+### Fixed
+
+- Pinned the `json` dependency to `< 3`. `graphql` (`~> 1.13`) calls `JSON.generate`/`.parse` with the legacy `quirks_mode:` option, which `json` 3.0 removed, so a fresh `bundle install` (this gem doesn't commit a `Gemfile.lock`) could resolve `json` 3.x and raise `ArgumentError: unknown keyword: quirks_mode` from `Schema#to_definition`/`#multiplex`.
+
 # [2.2.0] 2021-01-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,17 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Fixed** for any bug fixes.
 - **Security** in case of vulnerabilities.
 
-# [5.0.5] 2026-09-04
-
-### Changed
-
-- The `search_options` resolver no longer applies a default limit of 15 when the caller doesn't pass `with: { limit: }`. `default_limit:` now defaults to `nil`, so results are unbounded unless the caller passes `limit`, or the resource explicitly opts into a cap via `search_options(default_limit: N)`.
-
 # [5.0.4] 2026-09-03
 
 ### Changed
 
 - The `search_options` resolver (from `auto_register_search_options!`) now passes `current_user: context[:current_user]` and `current_application: context[:current_application]` through to the model's `.search_options(query, options)` call, alongside the existing `organization_id`/`with`. Additive — existing `.search_options` implementations that don't read those keys are unaffected. Lets a model's `search_options` call into `HasHelpers::Search.search` (which needs a real user/application), instead of being limited to plain ActiveRecord queries.
+- The `search_options` resolver no longer applies a default limit of 15 when the caller doesn't pass `with: { limit: }`. `default_limit:` now defaults to `nil`, so results are unbounded unless the caller passes `limit`, or the resource explicitly opts into a cap via `search_options(default_limit: N)`.
 
 # [2.2.0] 2021-01-27
 

--- a/hq-graphql.gemspec
+++ b/hq-graphql.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |s|
   s.add_dependency "graphql-batch",                              "~> 0.4"
   s.add_dependency "graphql-schema_comparator",                  "~> 1.0"
   s.add_dependency "pg",                                         "~> 1.1"
+  # graphql (~> 1.13) calls JSON.generate/.parse with the legacy `quirks_mode:` option,
+  # which json 3.0 removed support for (raises ArgumentError: unknown keyword: quirks_mode)
+  s.add_dependency "json",                                       "< 3"
 
   s.add_development_dependency "byebug",                         "~> 12.0"
   s.add_development_dependency "combustion",                     "~> 1.5"

--- a/lib/hq/graphql/resource.rb
+++ b/lib/hq/graphql/resource.rb
@@ -216,7 +216,8 @@ module HQ
         # already defines `.search_options`, so this rarely needs to be called explicitly.
         # Parameters:
         # field_name => overrides the generated field name
-        # default_limit => cap applied when the caller doesn't pass with: { limit: }
+        # default_limit => cap applied when the caller doesn't pass with: { limit: };
+        # when nil (the default), no limit is applied unless the caller passes one
         # type => the GraphQL type returned; defaults to HQ::GraphQL.config.default_search_type
         #
         # When an `Owner`-prefixed class exists for the model (e.g. `OwnerLevel` for
@@ -229,7 +230,7 @@ module HQ
         # those override whatever the Owner view returned for that record.
         OWNER_OVERRIDE_METHODS = %i[sub_item_type abbreviation].freeze
 
-        def search_options(field_name: nil, default_limit: 15, type: nil)
+        def search_options(field_name: nil, default_limit: nil, type: nil)
           return if @search_options_registered
 
           resource = self
@@ -248,10 +249,16 @@ module HQ
               owner_klass = "Owner#{klass.name}".safe_constantize
               opts = (with || {}).deep_symbolize_keys
 
-              scope = klass.search_options(query, organization_id: context[:current_organization]&.id, with: opts)
+              scope = klass.search_options(
+                query,
+                organization_id: context[:current_organization]&.id,
+                with: opts,
+                current_user: context[:current_user],
+                current_application: context[:current_application]
+              )
               limit = Integer(opts[:limit]) rescue default_limit
               is_relation = scope.respond_to?(:limit)
-              limited_scope = is_relation ? scope.limit(limit) : scope
+              limited_scope = (is_relation && limit) ? scope.limit(limit) : scope
               primary_key = klass.primary_key
 
               # `.search_options_groups` (e.g. Level#is_active?) needs real model

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "5.0.3"
+    VERSION = "5.0.5"
   end
 end

--- a/lib/hq/graphql/version.rb
+++ b/lib/hq/graphql/version.rb
@@ -2,6 +2,6 @@
 
 module HQ
   module GraphQL
-    VERSION = "5.0.5"
+    VERSION = "5.0.4"
   end
 end


### PR DESCRIPTION
Description
-----------
 - search_options no longer applies a default limit of 15 when the caller doesn't pass with: { limit: }. default_limit: now defaults to nil, so results are unbounded unless the caller explicitly passes
    limit, or the resource opts into a cap via search_options(default_limit: N).
  - The search_options resolver now forwards current_user: and current_application: from the GraphQL context into the model's .search_options(query, options) call, alongside the existing
    organization_id:/with:. This is additive — implementations that don't read those keys are unaffected — and lets a model's search_options call into HasHelpers::Search.search (which needs a real
    user/application) instead of being limited to plain ActiveRecord queries.
  - Pinned the json gem dependency to < 3. graphql (~> 1.13) internally calls JSON.generate/.parse with the legacy quirks_mode: option, which json 3.0 dropped support for. Since this gem doesn't commit a
    Gemfile.lock, a fresh bundle install (e.g. in CI) could resolve json 3.x and blow up with ArgumentError: unknown keyword: quirks_mode from Schema#to_definition/#multiplex — unrelated to any app
    code, just a version-resolution gap.
  - Bumped the ruby-pipelines chart dependency in .tekton/Chart.yaml to 0.2.0-dev.7.

  Test plan

  - bundle exec rspec — 245 examples, 0 failures, verified against a fresh bundle install (no cached lockfile) to match how CI resolves dependencies.

Risk Level
-----------
- [x] Low
- [ ] Med
- [ ] High

Rollback Plan
-----------
Please describe and add steps for rollback if needed. 

Screenshots
-----------
Screenshots or videos of the feature/fix if needed.

<!-- SOC2_CHECKLIST_START -->
Checklist
-----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I linked the change to an approved ticket
- [x] I have added/updated appropriate tests and evidence
- [x] I considered security/privacy impact
- [x] I updated docs/runbook if needed
- [x] I added a changelog/version entry for this PR
<!-- SOC2_CHECKLIST_END -->
